### PR TITLE
Fix too many arguments to if statement.

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -243,7 +243,7 @@ do
 
   RUNNING=`grep -e "RUNNING" results`
 
-  if [ $RUNNING ]; then
+  if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";
     exit 0
   fi


### PR DESCRIPTION
I ran into an issue of `./ecs-deploy: line 246: [: too many arguments` coming up. It looks like it was having some issues if there were multiple "Success" messages in results.