### PR TITLE
Use Script from Local Path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ RUN apt-get update -y \
         python-setuptools \
         jq \
     && easy_install pip \
-    && pip install awscli \
-    && curl -o /usr/local/bin/ecs-deploy https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy \
-    && chmod a+x /usr/local/bin/ecs-deploy
+    && pip install awscli
+
+COPY ecs-deploy /usr/local/bin/ecs-deploy
+
+RUN chmod a+x /usr/local/bin/ecs-deploy
 
 ENTRYPOINT ["/usr/local/bin/ecs-deploy"]


### PR DESCRIPTION
While working on another pull request I found myself wanting to make changes, build and test them without committing and pushing to Github first. Is there any reason not to copy over the script directly from the source code?