### PR TITLE
Use Image Name When Updating Task Definition

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -200,6 +200,7 @@ if [[ "x$img" != "x" ]]; then
     useImage="$useImage/$img"
   fi
 fi
+imageWithoutTag="$useImage"
 if [[ "x$tag" != "x" ]]; then
   useImage="$useImage:$tag"
 fi
@@ -214,7 +215,7 @@ echo "Current task definition: $TASK_DEFINITION";
 aws ecs describe-task-definition --task-def $TASK_DEFINITION > def
 
 # Update definition to use new image name
-sed -i def -e "s|\"image\": \".*\"|\"image\": \"${useImage}\"|"
+sed -i def -e "s|\"image\": \"${imageWithoutTag}.*\"|\"image\": \"${useImage}\"|"
 
 # Filter the def
 jq < def > newdef '.taskDefinition|{family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions}'


### PR DESCRIPTION
It's possible for a task definition to have more than one container (ie. web and redis). If so the existing script will swap out both for the new image name. 

For example I had a task definition that looked something like this:

```json
{
  "status": "ACTIVE",
  "family": "bot",
  "containerDefinitions": [
    {
      "name": "bot",
      "image": "technekes/bot:cc3813d066893fd6c4"
    },
    {
      "name": "redis",
      "image": "redis:latest"
    }
  ]
}
```

When I ran a deploy the script found both instances of `image` and replaced the value with the new image name/tag. I ended up with something like this:

```json
{
  "status": "ACTIVE",
  "family": "bot",
  "containerDefinitions": [
    {
      "name": "bot",
      "image": "technekes/bot:40495fa26f0bbc5d02"
    },
    {
      "name": "redis",
      "image": "technekes/bot:40495fa26f0bbc5d02"
    }
  ]
}
```

I've attempted to update the script to use the image without the tag name as an anchor for the regex to find just the appropriate node.