### PR TITLE
Update `sed` usage for compatibility

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -244,7 +244,7 @@ echo "Current task definition: $TASK_DEFINITION";
 $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION > def
 
 # Update definition to use new image name
-sed -i def -e "s|\"image\": \"${imageWithoutTag}.*\"|\"image\": \"${useImage}\"|"
+sed -i'' -e "s|\"image\": \"${imageWithoutTag}.*\"|\"image\": \"${useImage}\"|" def
 
 # Filter the def
 jq < def > newdef '.taskDefinition|{family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions}'


### PR DESCRIPTION
The existing implementation worked in GNU `sed` on Linux, but was failing on Mac OS X's BSD `sed`. This invocation works on both `sed`s.