### PR TITLE
Exposed min/max healthy percentage service deployment options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Usage
                                           silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
 
     Optional arguments:
+        -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment. (default: 100)
+        -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
         -v | --verbose          Verbose output

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Usage
 
       All options:
 
-        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -t 240 -e CI_TIMESTAMP -v
+        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -m 50 -M 100 -t 240 -e CI_TIMESTAMP -v
 
         Using profiles (for STS delegated credentials, for instance):
 
-        ecs-deploy -p PROFILE -c production1 -n doorman-service -i docker.repo.com/doorman -t 240 -e CI_TIMESTAMP -v
+        ecs-deploy -p PROFILE -c production1 -n doorman-service -i docker.repo.com/doorman -m 50 -M 100 -t 240 -e CI_TIMESTAMP -v
 
     Notes:
       - If a tag is not found in image and an ENV var is not used via -e, it will default the tag to "latest"

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -20,6 +20,8 @@ function usage() {
                                           silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
 
     Optional arguments:
+        -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment. (default: 100)
+        -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
         -v | --verbose          Verbose output
@@ -50,6 +52,8 @@ if [ $# == 0 ]; then usage; fi
 CLUSTER=false
 SERVICE=false
 IMAGE=false
+MIN=100
+MAX=200
 TIMEOUT=90
 VERBOSE=false
 TAGVAR=false
@@ -92,6 +96,14 @@ do
             ;;
         -t|--timeout)
             TIMEOUT="$2"
+            shift
+            ;;
+        -m|--min)
+            MIN="$2"
+            shift
+            ;;
+        -M|--max)
+            MAX="$2"
             shift
             ;;
         -e|--tag-env-var)
@@ -254,7 +266,7 @@ NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json file://newdef | 
 echo "New task definition: $NEW_TASKDEF";
 
 # Update the service
-UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF`
+UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF --deployment-configuration maximumPercent=$MAX,minimumHealthyPercent=$MIN`
 
 # See if the service is able to come up again
 every=10


### PR DESCRIPTION
Exposes the minimumHealthyPercent / maximumPercent service deployment options discussed here:

https://aws.amazon.com/blogs/compute/amazon-ecs-launches-new-deployment-capabilities-cloudwatch-metrics-singapore-and-frankfurt-regions/