### PR TITLE
Remove default values for --min and --max

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -270,7 +270,7 @@ fi
 if [ $MIN != false ]; then
   DEPLOYMENT_CONFIG="$DEPLOYMENT_CONFIG,minimumHealthyPercent=$MIN"
 fi
-if [ $DEPLOYMENT_CONFIG != "" ]; then
+if [ ! -z "$DEPLOYMENT_CONFIG" ]; then
   DEPLOYMENT_CONFIG="--deployment-configuration ${DEPLOYMENT_CONFIG:1}"
 fi
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -20,8 +20,8 @@ function usage() {
                                           silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
 
     Optional arguments:
-        -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment. (default: 100)
-        -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
+        -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment.
+        -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
         -v | --verbose          Verbose output
@@ -52,8 +52,8 @@ if [ $# == 0 ]; then usage; fi
 CLUSTER=false
 SERVICE=false
 IMAGE=false
-MIN=100
-MAX=200
+MIN=false
+MAX=false
 TIMEOUT=90
 VERBOSE=false
 TAGVAR=false
@@ -263,8 +263,19 @@ DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
 NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$DEF" | jq .taskDefinition.taskDefinitionArn | tr -d '"'`
 echo "New task definition: $NEW_TASKDEF";
 
+DEPLOYMENT_CONFIG=""
+if [ $MAX != false ]; then
+  DEPLOYMENT_CONFIG=",maximumPercent=$MAX"
+fi
+if [ $MIN != false ]; then
+  DEPLOYMENT_CONFIG="$DEPLOYMENT_CONFIG,minimumHealthyPercent=$MIN"
+fi
+if [ $DEPLOYMENT_CONFIG != "" ]; then
+  DEPLOYMENT_CONFIG="--deployment-configuration ${DEPLOYMENT_CONFIG:1}"
+fi
+
 # Update the service
-UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF --deployment-configuration maximumPercent=$MAX,minimumHealthyPercent=$MIN`
+UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
 
 # See if the service is able to come up again
 every=10


### PR DESCRIPTION
I'm really glad to see these options exposed in this tool, but I think setting default values for them is a mistake. These values are persisted as part of the service record, not just used per-deploy. For anyone (like me) who had set these values in the AWS console, running ecs-deploy without --min and --max will reset them back to 100/200 and potentially cause deploys to fail.

/cc: @kevinkarwaski 