### PR TITLE
Fix regression in d58e426d6233534d12cbd07332162d663303d714

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -293,7 +293,7 @@ do
     | jq '.taskArns[]' \
     | xargs -I{} $AWS_ECS describe-tasks --cluster $CLUSTER --tasks {} \
     | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.lastStatus" \
-    | grep -e "RUNNING" )
+    | grep -e "RUNNING" || : )
 
   if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";


### PR DESCRIPTION
In commit d58e426d6233534d12cbd07332162d663303d714 `set -e` was added in order for
the script to exit on errors since it would just continue trying to do things
otherwise. This didn't play well with `grep` that returns exit code 1 when it
doesn't match.