### PR TITLE
Allow underscores in username, image and tag

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -193,7 +193,7 @@ fi
 # - image
 # - tag
 # If a group is missing it will be an empty string
-imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9\-]+)/?([a-zA-Z0-9\-]+)?:?([a-zA-Z0-9\.\-]+)?$"
+imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9\-\_]+)/?([a-zA-Z0-9\-\_]+)?:?([a-zA-Z0-9\.\-\_]+)?$"
 
 if [[ $IMAGE =~ $imageRegex ]]; then
   # Define variables from matching groups


### PR DESCRIPTION
This PR enables the usage of underscores in the username, image or tags fields in the -i parameter.