### PR TITLE
Fix for the task definition rewrite sed command.

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -297,7 +297,7 @@ echo "Current task definition: $TASK_DEFINITION";
 # + Update definition to use new image name
 # + Filter the def
 DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
-        | sed -e "s|\"image\": \"${imageWithoutTag}.*\"|\"image\": \"${useImage}\"|" \
+        | sed -e "s|\"image\": \"${imageWithoutTag}(:.*)?\"|\"image\": \"${useImage}\"|" \
         | jq '.taskDefinition|{family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions}' )
 
 # Register the new task definition, and store its ARN


### PR DESCRIPTION
Prevent the rewrite of the task definition to update more than just the container you're updating the image for, if you have more than one container with the same name prefix.
eg.

servicename
servicename-web