### PR TITLE
Added Dockerfile_Alpine

### DIFF
--- a/Dockerfile_Alpine
+++ b/Dockerfile_Alpine
@@ -1,0 +1,15 @@
+FROM alpine:latest
+MAINTAINER Håkon Nymo Matland <hmatland>
+
+RUN \
+  apk update && \
+  apk upgrade && \
+  apk add bash curl py-pip jq && \
+  rm -rf /var/cache/apk/* && \
+  pip install awscli
+
+COPY ecs-deploy /usr/local/bin/ecs-deploy
+
+RUN chmod a+x /usr/local/bin/ecs-deploy
+
+ENTRYPOINT ["/usr/local/bin/ecs-deploy"]


### PR DESCRIPTION
Added Dockerfile_Alpine which may be used to create a Docker image based on Alpine Linux.
By using [Alpine linux](http://www.alpinelinux.org/) as the base image, the image size is reduced to ~83 MB, compared to the relative heavy 285 MB image based on Ubuntu.

Same usage instructions applies as with the regular Dockerfile, as the only thing I've changed is the base image, and installed packages with Alpine Linux' package manager [apk](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management)

To build from the Dockerfile_Alpine instead of Dockerfile, use the -f flag of docker build.
`docker build -t <repo>/ecs-deploy-alpine -f Dockerfile_Alpine .`
