### PR TITLE
Add AWS credentials file support

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -173,19 +173,6 @@ if [ $VERBOSE == true ]; then
     set -x
 fi
 
-# Make sure we have all the variables needed: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, CLUSTER, SERVICE, IMAGE
-if [ -z $AWS_IAM_ROLE ] && [ -z $AWS_ACCESS_KEY_ID ] && [ -z $AWS_PROFILE ]; then
-    echo "AWS_ACCESS_KEY_ID is required. You can set it as an environment variable or pass the value using -k or --aws-access-key"
-    exit 1
-fi
-if [ -z $AWS_IAM_ROLE ] && [ -z $AWS_SECRET_ACCESS_KEY ] && [ -z $AWS_PROFILE ]; then
-    echo "AWS_SECRET_ACCESS_KEY is required. You can set it as an environment variable or pass the value using -s or --aws-secret-key"
-    exit 1
-fi
-if [ -z $AWS_IAM_ROLE ] && [ -z $AWS_DEFAULT_REGION ] && [ -z $AWS_PROFILE ]; then
-    echo "AWS_DEFAULT_REGION is required. You can set it as an environment variable or pass the value using -r or --region"
-    exit 1
-fi
 if [ $SERVICE == false ] && [ $TASK_DEFINITION == false ]; then
     echo "One of SERVICE or TASK DEFINITON is required. You can pass the value using -n / --service-name for a service, or -d / --task-definiton for a task"
     exit 1


### PR DESCRIPTION
This is a quick change to support AWS credentials file.
If AWS credentials are already saved in `~/.aws/credentials` ([doc](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files)) *aws-cli* doesn't require `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as environment variables.