### PR TITLE
Deregister Outdated ECS Task Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage
         -M | --max                    maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout                Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var            Get image tag name from environment variable. If provided this will override value specified in image name argument.
+        --deregister-task             Deregister old Task Definition after a successful deployment.
         -v | --verbose                Verbose output
 
     Examples:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage
         --max-definitions             Number of Task Definition Revisions to persist before deregistering oldest revisions.
                                       Note: This number must be 1 or higher (i.e. keep only the current revision ACTIVE).
                                             Max definitions causes all task revisions not matching criteria to be deregistered, even if they're created manually.
-                                            Also will only perform deregistration if deployment succeeds.
+                                            Script will only perform deregistration if deployment succeeds.
         -v | --verbose                Verbose output
 
     Examples:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Usage
         -M | --max                    maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout                Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var            Get image tag name from environment variable. If provided this will override value specified in image name argument.
-        --deregister-task             Deregister old Task Definition after a successful deployment.
+        --max-definitions             Number of Task Definition Revisions to persist before deregistering oldest revisions.
+                                      Note: This number must be 1 or higher (i.e. keep only the current revision ACTIVE).
+                                            Max definitions causes all task revisions not matching criteria to be deregistered, even if they're created manually.
+                                            Also will only perform deregistration if deployment succeeds.
         -v | --verbose                Verbose output
 
     Examples:
@@ -158,7 +161,7 @@ Here's an example of a suitable custom policy for [AWS IAM](https://aws.amazon.c
 
 Troubleshooting
 ---------------
- - You must provide AWS credentials in one of the supported formats. If you do 
+ - You must provide AWS credentials in one of the supported formats. If you do
    not, you'll see some error output from the AWS CLI, something like:
 
         You must specify a region. You can also configure your region by running "aws configure".

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Here's an example of a suitable custom policy for [AWS IAM](https://aws.amazon.c
         "ecs:DescribeTaskDefinition",
         "ecs:DescribeTasks",
         "ecs:ListTasks",
+        "ecs:ListTaskDefinitions",
         "ecs:RegisterTaskDefinition",
         "ecs:StartTask",
         "ecs:StopTask",

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -29,6 +29,7 @@ function usage() {
         -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
+        --deregister-task       Deregister old Task Definition after a successful deployment.
         -v | --verbose          Verbose output
 
     Requirements:
@@ -78,6 +79,7 @@ require jq
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false
+DEREGISTER_TASK=false
 IMAGE=false
 MIN=false
 MAX=false
@@ -143,6 +145,9 @@ do
         -e|--tag-env-var)
             TAGVAR="$2"
             shift
+            ;;
+        --deregister-task)
+            DEREGISTER_TASK=true
             ;;
         -v|--verbose)
             VERBOSE=true
@@ -325,6 +330,13 @@ else
 
   if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";
+    
+    if [ $DEREGISTER_TASK == true ]; then
+        DEREGISTER=`$AWS_ECS deregister-task-definition --task-definition $TASK_DEFINITION`
+        
+        echo "Deregistered old task definition."
+    fi
+    
     exit 0
   fi
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -339,7 +339,7 @@ else
     if [[ $MAX_DEFINITIONS -gt 0 ]]; then
         FAMILY_PREFIX=${TASK_DEFINITION##*:task-definition/}
         FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
-        TASK_REVISIONS=`aws ecs list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
+        TASK_REVISIONS=`$AWS_ECS list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
 
         NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
 
@@ -350,7 +350,7 @@ else
 
                 echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
 
-                `aws ecs deregister-task-definition --task-definition $OUTDATED_REVISION_ARN`
+                `$AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN"`
             done
         fi
     fi

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -148,6 +148,7 @@ do
             ;;
         --max-definitions)
             MAX_DEFINITIONS="$2"
+            shift
             ;;
         -v|--verbose)
             VERBOSE=true

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -350,7 +350,7 @@ else
 
                 echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
 
-                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN"
+                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
             done
         fi
     fi

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -350,7 +350,7 @@ else
 
                 echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
 
-                `$AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN"`
+                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN"
             done
         fi
     fi

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -29,7 +29,7 @@ function usage() {
         -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
-        --deregister-task       Deregister old Task Definition after a successful deployment.
+        --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
         -v | --verbose          Verbose output
 
     Requirements:
@@ -79,7 +79,7 @@ require jq
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false
-DEREGISTER_TASK=false
+MAX_DEFINITIONS=0
 IMAGE=false
 MIN=false
 MAX=false
@@ -146,8 +146,8 @@ do
             TAGVAR="$2"
             shift
             ;;
-        --deregister-task)
-            DEREGISTER_TASK=true
+        --max-definitions)
+            MAX_DEFINITIONS="$2"
             ;;
         -v|--verbose)
             VERBOSE=true
@@ -192,6 +192,10 @@ if [ $SERVICE != false ] && [ $CLUSTER == false ]; then
 fi
 if [ $IMAGE == false ]; then
     echo "IMAGE is required. You can pass the value using -i or --image"
+    exit 1
+fi
+if ! [[ $MAX_DEFINITIONS =~ ^-?[0-9]+$ ]]; then
+    echo "MAX_DEFINITIONS must be numeric, or not defined."
     exit 1
 fi
 
@@ -330,13 +334,26 @@ else
 
   if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";
-    
-    if [ $DEREGISTER_TASK == true ]; then
-        DEREGISTER=`$AWS_ECS deregister-task-definition --task-definition $TASK_DEFINITION`
-        
-        echo "Deregistered old task definition."
+
+    if [[ $MAX_DEFINITIONS -gt 0 ]]; then
+        FAMILY_PREFIX=${TASK_DEFINITION##*:task-definition/}
+        FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
+        TASK_REVISIONS=`aws ecs list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
+
+        NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
+
+        if [[ $NUM_ACTIVE_REVISIONS -gt $MAX_DEFINITIONS ]]; then
+            LAST_OUTDATED_INDEX=$(($NUM_ACTIVE_REVISIONS - $MAX_DEFINITIONS - 1))
+            for i in $(seq 0 $LAST_OUTDATED_INDEX); do
+                OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
+
+                echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
+
+                `aws ecs deregister-task-definition --task-definition $OUTDATED_REVISION_ARN`
+            done
+        fi
     fi
-    
+
     exit 0
   fi
 


### PR DESCRIPTION
Adding the ability to deregister the old task definition when the new one has been deployed successfully will clear some of the clutter in the AWS Management Console, as the configurations would otherwise build up indefinitely.