### PR TITLE
avoid piping to the aws command

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -317,11 +317,11 @@ else
     # Scan the list of running tasks for that service, and see if one of them is the
     # new version of the task definition
 
-  RUNNING=$($AWS_ECS list-tasks --cluster $CLUSTER  --service-name $SERVICE --desired-status RUNNING \
-    | jq -r '.taskArns[]' \
-    | xargs -I{} $AWS_ECS describe-tasks --cluster $CLUSTER --tasks {} \
+  RUNNING_TASKS=$($AWS_ECS list-tasks --cluster "$CLUSTER"  --service-name "$SERVICE" --desired-status RUNNING \
+      | jq -r '.taskArns[]')
+  RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks $RUNNING_TASKS \
     | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.lastStatus" \
-    | grep -e "RUNNING" || : )
+    | grep -e "RUNNING") || :
 
   if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";


### PR DESCRIPTION
This is perhaps specific to my setup. However, breaking up pipes when they are small is a technique towards producing better error messages (you can check intermediate states) so I think this is still a good change overall.


I run the `aws` command from a docker container with `-it` set.
This causes the error

    cannot enable tty mode on non tty input

Also quote some variables