### PR TITLE
Adding support for --desired-count parameter on update-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Usage
                                                 silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
 
     Optional arguments:
+        -D | --desired-count          The number of instantiations of the task to place and keep running in your service.
         -m | --min                    minumumHealthyPercent: The lower limit on the number of running tasks during a deployment. (default: 100)
         -M | --max                    maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout                Default is 90s. Script monitors ECS Service for new task definition to be running.
@@ -33,7 +34,7 @@ Usage
 
       All options:
 
-        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -m 50 -M 100 -t 240 -e CI_TIMESTAMP -v
+        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -m 50 -M 100 -t 240 -D 2 -e CI_TIMESTAMP -v
 
         Using profiles (for STS delegated credentials, for instance):
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -25,6 +25,7 @@ function usage() {
         --aws-instance-profile  Use the IAM role associated with this instance
 
     Optional arguments:
+        -D | --desired-count    The number of instantiations of the task to place and keep running in your service.
         -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment.
         -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
@@ -138,6 +139,10 @@ do
             ;;
         -M|--max)
             MAX="$2"
+            shift
+            ;;
+        -D|--desired-count)
+            DESIRED="$2"
             shift
             ;;
         -e|--tag-env-var)
@@ -306,8 +311,13 @@ else
     DEPLOYMENT_CONFIG="--deployment-configuration ${DEPLOYMENT_CONFIG:1}"
   fi
 
+  DESIRED_COUNT=""
+  if [ $DESIRED != false ]; then
+    DESIRED_COUNT="--desired-count $DESIRED"
+  fi
+
   # Update the service
-  UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
+  UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE $DESIRED_COUNT --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
 
   # See if the service is able to come up again
   every=10


### PR DESCRIPTION
./ecs-deploy -p default -c Cluster -n Service -i image:tag -m 50 -M 200 -t 300 -D 4

The `-D 4` will set the desired-count to 4 while updating service. 