### PR TITLE
Support for deregistering old task definitions and setting desired count of tasks for service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Usage
         -M | --max                    maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout                Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var            Get image tag name from environment variable. If provided this will override value specified in image name argument.
+        --max-definitions             Number of Task Definition Revisions to persist before deregistering oldest revisions.
+                                      Note: This number must be 1 or higher (i.e. keep only the current revision ACTIVE).
+                                            Max definitions causes all task revisions not matching criteria to be deregistered, even if they're created manually.
+                                            Script will only perform deregistration if deployment succeeds.
         -v | --verbose                Verbose output
 
     Examples:
@@ -144,6 +148,7 @@ Here's an example of a suitable custom policy for [AWS IAM](https://aws.amazon.c
         "ecs:DescribeTaskDefinition",
         "ecs:DescribeTasks",
         "ecs:ListTasks",
+        "ecs:ListTaskDefinitions",
         "ecs:RegisterTaskDefinition",
         "ecs:StartTask",
         "ecs:StopTask",
@@ -157,7 +162,7 @@ Here's an example of a suitable custom policy for [AWS IAM](https://aws.amazon.c
 
 Troubleshooting
 ---------------
- - You must provide AWS credentials in one of the supported formats. If you do 
+ - You must provide AWS credentials in one of the supported formats. If you do
    not, you'll see some error output from the AWS CLI, something like:
 
         You must specify a region. You can also configure your region by running "aws configure".

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Usage
                                                 silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
 
     Optional arguments:
+        -D | --desired-count          The number of instantiations of the task to place and keep running in your service.
         -m | --min                    minumumHealthyPercent: The lower limit on the number of running tasks during a deployment. (default: 100)
         -M | --max                    maximumPercent: The upper limit on the number of running tasks during a deployment. (default: 200)
         -t | --timeout                Default is 90s. Script monitors ECS Service for new task definition to be running.
@@ -37,7 +38,7 @@ Usage
 
       All options:
 
-        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -m 50 -M 100 -t 240 -e CI_TIMESTAMP -v
+        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -m 50 -M 100 -t 240 -D 2 -e CI_TIMESTAMP -v
 
         Using profiles (for STS delegated credentials, for instance):
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -317,11 +317,11 @@ else
     # Scan the list of running tasks for that service, and see if one of them is the
     # new version of the task definition
 
-  RUNNING=$($AWS_ECS list-tasks --cluster $CLUSTER  --service-name $SERVICE --desired-status RUNNING \
-    | jq -r '.taskArns[]' \
-    | xargs -I{} $AWS_ECS describe-tasks --cluster $CLUSTER --tasks {} \
+  RUNNING_TASKS=$($AWS_ECS list-tasks --cluster "$CLUSTER"  --service-name "$SERVICE" --desired-status RUNNING \
+      | jq -r '.taskArns[]')
+  RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks $RUNNING_TASKS \
     | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.lastStatus" \
-    | grep -e "RUNNING" || : )
+    | grep -e "RUNNING") || :
 
   if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -25,6 +25,7 @@ function usage() {
         --aws-instance-profile  Use the IAM role associated with this instance
 
     Optional arguments:
+        -D | --desired-count    The number of instantiations of the task to place and keep running in your service.
         -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment.
         -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
@@ -140,6 +141,10 @@ do
             ;;
         -M|--max)
             MAX="$2"
+            shift
+            ;;
+        -D|--desired-count)
+            DESIRED="$2"
             shift
             ;;
         -e|--tag-env-var)
@@ -316,8 +321,13 @@ else
     DEPLOYMENT_CONFIG="--deployment-configuration ${DEPLOYMENT_CONFIG:1}"
   fi
 
+  DESIRED_COUNT=""
+  if [ $DESIRED != false ]; then
+    DESIRED_COUNT="--desired-count $DESIRED"
+  fi
+
   # Update the service
-  UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
+  UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE $DESIRED_COUNT --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
 
   # Only excepts RUNNING state from services whose desired-count > 0
   SERVICE_DESIREDCOUNT=`$AWS_ECS describe-services --cluster $CLUSTER --service $SERVICE | jq '.services[]|.desiredCount'`

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -322,7 +322,7 @@ else
   fi
 
   DESIRED_COUNT=""
-  if [ $DESIRED != false ]; then
+  if [ ! -z "$DESIRED" ]; then
     DESIRED_COUNT="--desired-count $DESIRED"
   fi
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -29,6 +29,7 @@ function usage() {
         -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
+        --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
         -v | --verbose          Verbose output
 
     Requirements:
@@ -78,6 +79,7 @@ require jq
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false
+MAX_DEFINITIONS=0
 IMAGE=false
 MIN=false
 MAX=false
@@ -144,6 +146,10 @@ do
             TAGVAR="$2"
             shift
             ;;
+        --max-definitions)
+            MAX_DEFINITIONS="$2"
+            shift
+            ;;
         -v|--verbose)
             VERBOSE=true
             ;;
@@ -187,6 +193,10 @@ if [ $SERVICE != false ] && [ $CLUSTER == false ]; then
 fi
 if [ $IMAGE == false ]; then
     echo "IMAGE is required. You can pass the value using -i or --image"
+    exit 1
+fi
+if ! [[ $MAX_DEFINITIONS =~ ^-?[0-9]+$ ]]; then
+    echo "MAX_DEFINITIONS must be numeric, or not defined."
     exit 1
 fi
 
@@ -325,6 +335,26 @@ else
 
   if [ "$RUNNING" ]; then
     echo "Service updated successfully, new task definition running.";
+
+    if [[ $MAX_DEFINITIONS -gt 0 ]]; then
+        FAMILY_PREFIX=${TASK_DEFINITION##*:task-definition/}
+        FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
+        TASK_REVISIONS=`$AWS_ECS list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
+
+        NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
+
+        if [[ $NUM_ACTIVE_REVISIONS -gt $MAX_DEFINITIONS ]]; then
+            LAST_OUTDATED_INDEX=$(($NUM_ACTIVE_REVISIONS - $MAX_DEFINITIONS - 1))
+            for i in $(seq 0 $LAST_OUTDATED_INDEX); do
+                OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
+
+                echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
+
+                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
+            done
+        fi
+    fi
+
     exit 0
   fi
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -319,50 +319,56 @@ else
   # Update the service
   UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
 
-  # See if the service is able to come up again
-  every=10
-  i=0
-  while [ $i -lt $TIMEOUT ]
-  do
-    # Scan the list of running tasks for that service, and see if one of them is the
-    # new version of the task definition
+  # Only excepts RUNNING state from services whose desired-count > 0
+  SERVICE_DESIREDCOUNT=`$AWS_ECS describe-services --cluster $CLUSTER --service $SERVICE | jq '.services[]|.desiredCount'`
+  if [ $SERVICE_DESIREDCOUNT -gt 0 ]; then
+    # See if the service is able to come up again
+    every=10
+    i=0
+    while [ $i -lt $TIMEOUT ]
+    do
+      # Scan the list of running tasks for that service, and see if one of them is the
+      # new version of the task definition
 
-  RUNNING_TASKS=$($AWS_ECS list-tasks --cluster "$CLUSTER"  --service-name "$SERVICE" --desired-status RUNNING \
-      | jq -r '.taskArns[]')
-  RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks $RUNNING_TASKS \
-    | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.lastStatus" \
-    | grep -e "RUNNING") || :
+      RUNNING_TASKS=$($AWS_ECS list-tasks --cluster "$CLUSTER"  --service-name "$SERVICE" --desired-status RUNNING \
+          | jq -r '.taskArns[]')
+      RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks $RUNNING_TASKS \
+        | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.lastStatus" \
+        | grep -e "RUNNING") || :
 
-  if [ "$RUNNING" ]; then
-    echo "Service updated successfully, new task definition running.";
+      if [ "$RUNNING" ]; then
+        echo "Service updated successfully, new task definition running.";
 
-    if [[ $MAX_DEFINITIONS -gt 0 ]]; then
-        FAMILY_PREFIX=${TASK_DEFINITION##*:task-definition/}
-        FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
-        TASK_REVISIONS=`$AWS_ECS list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
+        if [[ $MAX_DEFINITIONS -gt 0 ]]; then
+            FAMILY_PREFIX=${TASK_DEFINITION##*:task-definition/}
+            FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
+            TASK_REVISIONS=`$AWS_ECS list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
 
-        NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
+            NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
 
-        if [[ $NUM_ACTIVE_REVISIONS -gt $MAX_DEFINITIONS ]]; then
-            LAST_OUTDATED_INDEX=$(($NUM_ACTIVE_REVISIONS - $MAX_DEFINITIONS - 1))
-            for i in $(seq 0 $LAST_OUTDATED_INDEX); do
-                OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
+            if [[ $NUM_ACTIVE_REVISIONS -gt $MAX_DEFINITIONS ]]; then
+                LAST_OUTDATED_INDEX=$(($NUM_ACTIVE_REVISIONS - $MAX_DEFINITIONS - 1))
+                for i in $(seq 0 $LAST_OUTDATED_INDEX); do
+                    OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
 
-                echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
+                    echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
 
-                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
-            done
+                    $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
+                done
+            fi
         fi
-    fi
 
-    exit 0
+        exit 0
+      fi
+
+      sleep $every
+      i=$(( $i + $every ))
+    done
+
+    # Timeout
+    echo "ERROR: New task definition not running within $TIMEOUT seconds"
+    exit 1
+  else
+    echo "Skipping check for running task definition, as desired-count <= 0"
   fi
-
-    sleep $every
-    i=$(( $i + $every ))
-  done
-
-  # Timeout
-  echo "ERROR: New task definition not running within $TIMEOUT seconds"
-  exit 1
 fi


### PR DESCRIPTION
Does anyone have objections to this being merged into master and tagged as a new release? I'll wait a day or two to merge it in. 