### PR TITLE
Resolved Undefined $DESIRED Variable

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -322,7 +322,7 @@ else
   fi
 
   DESIRED_COUNT=""
-  if [ $DESIRED != false ]; then
+  if [ ! -z "$DESIRED" ]; then
     DESIRED_COUNT="--desired-count $DESIRED"
   fi
 


### PR DESCRIPTION
This is causing an error when the variable is not defined (i.e. argument not being passed in).