### PR TITLE
Added networkMode option for task definitions

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -286,7 +286,7 @@ echo "Current task definition: $TASK_DEFINITION";
 DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
         | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
         | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
-        | jq '.taskDefinition|{family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions}' )
+        | jq '.taskDefinition|if .networkMode then {family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, networkMode: .networkMode} else {family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions} end' )
 
 # Register the new task definition, and store its ARN
 NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$DEF" | jq -r .taskDefinition.taskDefinitionArn`


### PR DESCRIPTION
This commit adds support for the newly introduced network mode in ECS. 
The solution requires the IF statement because ECS task definitions with network mode "bridge" will not print the networkMode attribute to the JSON output, whereas task definitions with network mode "host" will.