### PR TITLE
Fix #70 Double slash in image name

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -275,7 +275,9 @@ if [[ ! -z ${port} ]]; then
   useImage="$useImage:$port"
 fi
 if [[ ! -z ${repo+undefined-guard} ]]; then
+ if [[ ! "x$repo" == "x" ]]; then
   useImage="$useImage/$repo"
+ fi
 fi
 if [[ ! -z ${img+undefined-guard} ]]; then
   if [[ "x$useImage" == "x" ]]; then


### PR DESCRIPTION
If repo is empty do not add a trailing slash