### PR TITLE
Revert "update the image with jq, not sed"

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -303,10 +303,10 @@ echo "Current task definition: $TASK_DEFINITION";
 # Get a JSON representation of the current task definition
 # + Update definition to use new image name
 # + Filter the def
-td=$($AWS_ECS describe-task-definition --task-def "$TASK_DEFINITION" \
-    | jq '.taskDefinition')
-changedDefinition=$(echo "$td" | jq ".containerDefinitions | [.[] | .+{image: \"$useImage\"}]")
-DEF=$(echo "$td" | jq ".+{containerDefinitions: $changedDefinition}")
+DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
+        | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
+        | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
+        | jq '.taskDefinition|if .networkMode then {family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, networkMode: .networkMode} else {family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions} end' )
 
 # Default JQ filter for new task definition
 NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions"


### PR DESCRIPTION
This reverts commit cc75ef18a1fbaf595476c97e3ef0720d20c5f336.

Git got confused about this revert, but it seemed straightforward enough to me.

Warning: this is untested. It is difficult for me to properly test since the old version didn't work right for me.