### PR TITLE
Allow dots in image names

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -216,7 +216,7 @@ fi
 # - image
 # - tag
 # If a group is missing it will be an empty string
-imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9_-]+)/?([a-zA-Z0-9_-]+)?:?([a-zA-Z0-9\._-]+)?$"
+imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9._-]+)/?([a-zA-Z0-9._-]+)?:?([a-zA-Z0-9\._-]+)?$"
 
 if [[ $IMAGE =~ $imageRegex ]]; then
   # Define variables from matching groups


### PR DESCRIPTION
Amazon ECR allows dots in the names of repositories, but this script
does not. Just updating the regex to be more permissive.