### PR TITLE
Fix missing `taskRoleArn` parameter in new defintion

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -306,7 +306,7 @@ echo "Current task definition: $TASK_DEFINITION";
 DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
         | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
         | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
-        | jq '.taskDefinition|if .networkMode then {family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, networkMode: .networkMode} else {family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions} end' )
+        | jq '.taskDefinition' )
 
 # Default JQ filter for new task definition
 NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions"


### PR DESCRIPTION
### Remove filtering when retrieving the entire task definition
By passing in the filter to `jq '.taskDefinition'` the `taskRoleArn` values are lost. The filter seems to be a legacy artifact, as the code-block underneath already checks for both `networkMode` and `taskRoleArn` and includes them in the new task definition when present in the old one.

Addresses issue #76.