### PR TITLE
Feature/tagonly

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -32,6 +32,7 @@ function usage() {
         -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
         -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
         -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
+        -to | --tag-only        New tag to apply to all images defined in the task (multi-container task). If provided this will override value specified in image name argument.
         --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
         -v | --verbose          Verbose output
 
@@ -56,8 +57,12 @@ function usage() {
 
         ecs-deploy -p PROFILE -c production1 -n doorman-service -i docker.repo.com/doorman -t 240 -e CI_TIMESTAMP -v
 
+      Update just the tag on whatever image is found in ECS Task (supports multi-container tasks):
+
+        ecs-deploy -c staging -n core-service -to 0.1.899 -i ignore
+
     Notes:
-      - If a tag is not found in image and an ENV var is not used via -e, it will default the tag to "latest"
+      - If a tag is not found in image and an ENV var is not used via -e and a tag is not provided with -to, it will default the tag to "latest"
 EOM
 
     exit 2
@@ -154,6 +159,10 @@ do
             TAGVAR="$2"
             shift
             ;;
+        -to|--tag-only)
+            TAGONLY="$2"
+            shift
+            ;;
         --max-definitions)
             MAX_DEFINITIONS="$2"
             shift
@@ -216,30 +225,37 @@ fi
 # - image
 # - tag
 # If a group is missing it will be an empty string
-imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9._-]+)/?([a-zA-Z0-9._-]+)?:?([a-zA-Z0-9\._-]+)?$"
+if [[ "x$TAGONLY" == "x" ]]; then
+  imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9._-]+)/?([a-zA-Z0-9._-]+)?:?([a-zA-Z0-9\._-]+)?$"
+else 
+  imageRegex="^:?([a-zA-Z0-9\._-]+)?$"
+fi
 
 if [[ $IMAGE =~ $imageRegex ]]; then
   # Define variables from matching groups
-  domain=${BASH_REMATCH[1]}
-  port=${BASH_REMATCH[2]}
-  repo=${BASH_REMATCH[3]}
-  img=${BASH_REMATCH[4]}
-  tag=${BASH_REMATCH[5]}
+  if [[ "x$TAGONLY" == "x" ]]; then
+    domain=${BASH_REMATCH[1]}
+    port=${BASH_REMATCH[2]}
+    repo=${BASH_REMATCH[3]}
+    img=${BASH_REMATCH[4]}
+    tag=${BASH_REMATCH[5]}
 
-  # Validate what we received to make sure we have the pieces needed
-  if [[ "x$domain" == "x" ]]; then
-    echo "Image name does not contain a domain or repo as expected. See usage for supported formats." && exit 1;
-  fi
-  if [[ "x$repo" == "x" ]]; then
-    echo "Image name is missing the actual image name. See usage for supported formats." && exit 1;
-  fi
+    # Validate what we received to make sure we have the pieces needed
+    if [[ "x$domain" == "x" ]]; then
+      echo "Image name does not contain a domain or repo as expected. See usage for supported formats." && exit 1;
+    fi
+    if [[ "x$repo" == "x" ]]; then
+      echo "Image name is missing the actual image name. See usage for supported formats." && exit 1;
+    fi
 
-  # When a match for image is not found, the image name was picked up by the repo group, so reset variables
-  if [[ "x$img" == "x" ]]; then
-    img=$repo
-    repo=""
+    # When a match for image is not found, the image name was picked up by the repo group, so reset variables
+    if [[ "x$img" == "x" ]]; then
+      img=$repo
+      repo=""
+    fi
+  else 
+    tag=${BASH_REMATCH[1]}
   fi
-
 else
   # check if using root level repo with format like mariadb or mariadb:latest
   rootRepoRegex="^([a-zA-Z0-9\-]+):?([a-zA-Z0-9\.\-]+)?$"
@@ -268,30 +284,35 @@ fi
 
 # Reassemble image name
 useImage=""
-if [[ ! -z ${domain+undefined-guard} ]]; then
-  useImage="$domain"
-fi
-if [[ ! -z ${port} ]]; then
-  useImage="$useImage:$port"
-fi
-if [[ ! -z ${repo+undefined-guard} ]]; then
- if [[ ! "x$repo" == "x" ]]; then
-  useImage="$useImage/$repo"
- fi
-fi
-if [[ ! -z ${img+undefined-guard} ]]; then
-  if [[ "x$useImage" == "x" ]]; then
-    useImage="$img"
-  else
-    useImage="$useImage/$img"
+if [[ "x$TAGONLY" == "x" ]]; then
+  if [[ ! -z ${domain+undefined-guard} ]]; then
+    useImage="$domain"
   fi
-fi
-imageWithoutTag="$useImage"
-if [[ ! -z ${tag+undefined-guard} ]]; then
-  useImage="$useImage:$tag"
-fi
+  if [[ ! -z ${port} ]]; then
+    useImage="$useImage:$port"
+  fi
+  if [[ ! -z ${repo+undefined-guard} ]]; then
+   if [[ ! "x$repo" == "x" ]]; then
+    useImage="$useImage/$repo"
+   fi
+  fi
+  if [[ ! -z ${img+undefined-guard} ]]; then
+    if [[ "x$useImage" == "x" ]]; then
+      useImage="$img"
+    else
+      useImage="$useImage/$img"
+    fi
+  fi
+  imageWithoutTag="$useImage"
+  if [[ ! -z ${tag+undefined-guard} ]]; then
+    useImage="$useImage:$tag"
+  fi
 
-echo "Using image name: $useImage"
+  echo "Using image name: $useImage"
+else
+  useImage="$TAGONLY"
+  echo "Image tag-only replacement: $useImage"
+fi
 
 if [ $SERVICE != false ]; then
   # Get current task definition name from service
@@ -303,10 +324,16 @@ echo "Current task definition: $TASK_DEFINITION";
 # Get a JSON representation of the current task definition
 # + Update definition to use new image name
 # + Filter the def
-DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
+if [[ "x$TAGONLY" == "x" ]]; then
+  DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
         | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
         | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
         | jq '.taskDefinition' )
+else 
+  DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
+        | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" \
+        | jq '.taskDefinition' )
+fi
 
 # Default JQ filter for new task definition
 NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions"


### PR DESCRIPTION
Hi. I added a simple feature to the script to allow for a "tag-only" change (new -to flag). 

This feature supports simply providing a new tag, and that tag will be applied to whatever images are in the ECS Task.  This allows us to simply modify image version(s) of a Service/Task without needing to worry about the actual full image name.  The primary reason for this is to support ECS Tasks with multiple containers defined. The tag-only flag will apply the same tag to all of the images in the Task. This works very nice for our environment where we consolidate multiple containers within a single Task and can now redeploy the referencing Service with all new images. 

I've ensured that this flag is completely optional and does not change at all the original script logic should  it never be used. The -i and -e tags work the same as they had.