### PR TITLE
Add iam:PassRole to example IAM Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Here's an example of a suitable custom policy for [AWS IAM](https://aws.amazon.c
         "ecs:RegisterTaskDefinition",
         "ecs:StartTask",
         "ecs:StopTask",
-        "ecs:UpdateService"
+        "ecs:UpdateService",
+        "iam:PassRole"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
It looks like the `iam:PassRole` permission is also required for creating tasks.