### PR TITLE
Remove ENTRYPOINT from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,3 @@ RUN apt-get update -y \
 COPY ecs-deploy /usr/local/bin/ecs-deploy
 
 RUN chmod a+x /usr/local/bin/ecs-deploy
-
-ENTRYPOINT ["/usr/local/bin/ecs-deploy"]


### PR DESCRIPTION
I'm not sure if the entrypoint is specified on purpose, but it disables the possibility to use this image in CI systems (specifically gitlab-ci). By removing the entrypoint the setup could be something like:

```
update-service:
  image: silintl/ecs-deploy
  stage: update-service
  script:
    - ecs-deploy -c ... -n ... -i ...
```