### PR TITLE
Fixed typo

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -108,7 +108,7 @@ function assertRequiredArgumentsSet() {
     fi
 
     if [ $SERVICE == false ] && [ $TASK_DEFINITION == false ]; then
-        echo "One of SERVICE or TASK DEFINITON is required. You can pass the value using -n / --service-name for a service, or -d / --task-definiton for a task"
+        echo "One of SERVICE or TASK DEFINITON is required. You can pass the value using -n / --service-name for a service, or -d / --task-definition for a task"
         exit 5
     fi
     if [ $SERVICE != false ] && [ $TASK_DEFINITION != false ]; then


### PR DESCRIPTION
Hi !

I found a typo `--task-definiton` when I tried using ecs-deploy.

> $ ./ecs-deploy -c my-cluster
One of SERVICE or TASK DEFINITON is required. You can pass the value using -n / --service-name for a service, or -d / --task-definiton for a task

Thanks 👍 