### PR TITLE
Include placementConstraints when regenerating task definition

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -261,7 +261,7 @@ function createNewTaskDefJson() {
     fi
 
     # Default JQ filter for new task definition
-    NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions"
+    NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.


### PR DESCRIPTION
If you have specified placement constraints in your task definition (i.e. only deploy these to this instance), they won't get included when the task generation gets regenerated, for a new deployment. This includes them. 