### PR TITLE
fix task-definition only update bug, #115

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -239,10 +239,13 @@ function parseImageName() {
 
 function getCurrentTaskDefinition() {
     if [ $SERVICE != false ]; then
-      # Get current task definition name from service
+      # Get current task definition arn from service
       TASK_DEFINITION_ARN=`$AWS_ECS describe-services --services $SERVICE --cluster $CLUSTER | jq -r .services[0].taskDefinition`
-      TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
+    elif [ $TASK_DEFINITION != false ]; then
+      # Get current task definition arn from family[:revision] (or arn)
+      TASK_DEFINITION_ARN=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION | jq -r .taskDefinition.taskDefinitionArn`
     fi
+    TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
 }
 
 function createNewTaskDefJson() {


### PR DESCRIPTION
Fixes https://github.com/silinternational/ecs-deploy/issues/115 where the script would exit with `TASK_DEFINITION_ARN: unbound variable`. Also fixes another bug down the line where a task definition is expected during `createNewTaskDefJson()` but all we have is a task definition name.