### PR TITLE
Append the option to deploy from local task definition file

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -11,6 +11,7 @@ MAX=false
 TIMEOUT=90
 VERBOSE=false
 TAGVAR=false
+TASK_DEF_FILE=false
 TAGONLY=""
 ENABLE_ROLLBACK=false
 AWS_CLI=$(which aws)
@@ -43,6 +44,7 @@ Optional arguments:
     -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment.
     -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
     -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
+    -f | --task-def-file    Path to the custom task definition file in your filesystem. If provided this will update and register task definition from the file instead of just upgrading existing one. Use if you want to replace something in task definition.
     -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
     -to | --tag-only        New tag to apply to all images defined in the task (multi-container task). If provided this will override value specified in image name argument.
     --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
@@ -241,7 +243,11 @@ function getCurrentTaskDefinition() {
     if [ $SERVICE != false ]; then
       # Get current task definition name from service
       TASK_DEFINITION_ARN=`$AWS_ECS describe-services --services $SERVICE --cluster $CLUSTER | jq -r .services[0].taskDefinition`
-      TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
+      if [ $TASK_DEF_FILE != false ]; then
+        TASK_DEFINITION=$(cat $TASK_DEF_FILE)
+      else
+        TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
+      fi
     fi
 }
 
@@ -249,15 +255,27 @@ function createNewTaskDefJson() {
     # Get a JSON representation of the current task definition
     # + Update definition to use new image name
     # + Filter the def
-    if [[ "x$TAGONLY" == "x" ]]; then
-      DEF=$( echo "$TASK_DEFINITION" \
-            | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
-            | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
-            | jq '.taskDefinition' )
+    if [ $TASK_DEF_FILE != false ]; then
+      # There is no jq filter because we get the task definition itself directly from file
+      if [[ "x$TAGONLY" == "x" ]]; then
+        DEF=$( echo "$TASK_DEFINITION" \
+              | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
+              | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" )
+      else
+        DEF=$( echo "$TASK_DEFINITION" \
+              | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" )
+      fi
     else
-      DEF=$( echo "$TASK_DEFINITION" \
-            | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" \
-            | jq '.taskDefinition' )
+      if [[ "x$TAGONLY" == "x" ]]; then
+        DEF=$( echo "$TASK_DEFINITION" \
+              | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
+              | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
+              | jq '.taskDefinition' )
+      else
+        DEF=$( echo "$TASK_DEFINITION" \
+              | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" \
+              | jq '.taskDefinition' )
+      fi
     fi
 
     # Default JQ filter for new task definition
@@ -274,7 +292,8 @@ function createNewTaskDefJson() {
     done
 
     # Build new DEF with jq filter
-    NEW_DEF=$(echo $DEF | jq "{${NEW_DEF_JQ_FILTER}}")
+    # If there is no volume in definition - insert empty list by jq
+    NEW_DEF=$(echo $DEF | jq "{${NEW_DEF_JQ_FILTER}}" | jq '(.. | select(objects | has("volumes"))).volumes //= []' )
 
     # If in test mode output $NEW_DEF
     if [ "$BASH_SOURCE" != "$0" ]; then
@@ -476,6 +495,10 @@ if [ "$BASH_SOURCE" == "$0" ]; then
                 ;;
             -D|--desired-count)
                 DESIRED="$2"
+                shift
+                ;;
+            -f|--task-def-file)
+                TASK_DEF_FILE="$2"
                 shift
                 ;;
             -e|--tag-env-var)

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -244,10 +244,15 @@ function getCurrentTaskDefinition() {
       # Get current task definition name from service
       TASK_DEFINITION_ARN=`$AWS_ECS describe-services --services $SERVICE --cluster $CLUSTER | jq -r .services[0].taskDefinition`
       if [ $TASK_DEF_FILE != false ]; then
-        TASK_DEFINITION=$(cat $TASK_DEF_FILE)
+        TASK_DEFINITION=$(cat $TASK_DEF_FILE) || echo "Error! Task definition file not found"
       else
         TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
       fi
+
+      if [ "$TASK_DEFINITION" == "" ]
+        then exit 1
+      fi
+
     fi
 }
 


### PR DESCRIPTION
The issue: for now `ecs-deploy` just updates the current task definition, but can't deplot the new one with modifications. It's a kind of annoying if you want to append the volume to your container, tweak cpu/memory settings etc..

Hence, here I tried to append this feature trying to leave the current core functionality consistent and healthy.

A couple of notions:

1) If we use the local task def file, there is no reason for filter `jq .taskDefinition`. So, I removed that from file existence case.
2) Appended one more jq filter when generationg `NEW_DEF` filter to convert a `null` volume values to the empty line. This should work if we don't want to declare `volume` directive in our task definition. Without this filter, AWS API returns error about data type mismactching.

Finally, I provide the example of task definitions I used to deploy.

Without volumes

```
{
  "containerDefinitions": [
    {
      "name": "test1",
      "image": "1234567890.dkr.ecr.eu-central-1.amazonaws.com/test1:latest",
      "memory": 1024,
      "cpu": 1024,
      "essential": true,
      "portMappings": [
        {
          "hostPort": 0,
          "containerPort": 8080,
          "protocol": "tcp"
        }
      ],
      "ulimits": [
        {
          "softLimit": 8192,
          "hardLimit": 8192,
          "name": "nofile"
        }
      ],
      "logConfiguration": {
          "logDriver": "fluentd",
          "options": {
            "fluentd-address": "127.0.0.1:24224",
            "tag": "my.app.test1"
          }
      }
    }
  ],
  "family": "test1"
}
```

With volumes

```
{
  "containerDefinitions": [
    {
      "name": "test2",
      "image": "507902546598.dkr.ecr.us-east-1.amazonaws.com/test2:latest",
      "memory": 2048,
      "cpu": 2048,
      "essential": true,
      "portMappings": [
        {
          "hostPort": 0,
          "containerPort": 8080,
          "protocol": "tcp"
        }
      ],
      "ulimits": [
        {
          "softLimit": 8192,
          "hardLimit": 8192,
          "name": "nofile"
        }
      ],
      "mountPoints": [
        {
          "containerPath": "/var/run/td-agent/td-agent.sock",
          "sourceVolume": "fluentd-sock"
        }
      ],
      "logConfiguration": {
          "logDriver": "fluentd",
          "options": {
            "fluentd-address": "127.0.0.1:24224",
            "tag": "my.app.test2"
          }
      }
    }
  ],
  "volumes": [
    {
      "host": {
        "sourcePath": "/var/run/td-agent/td-agent.sock"
      },
      "name": "fluentd-sock"
    }
  ],
  "family": "test2"
}
```