### PR TITLE
Supported AWS Fargate

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -275,6 +275,13 @@ function createNewTaskDefJson() {
       fi
     done
 
+    # Updated jq filters for AWS Fargate
+    REQUIRES_COMPATIBILITIES=$(echo "${DEF}" | jq -r '. | select(.requiresCompatibilities != null) | .requiresCompatibilities[]')
+    if [[ "${REQUIRES_COMPATIBILITIES}" == 'FARGATE' ]]; then
+      FARGATE_JQ_FILTER='executionRoleArn: .executionRoleArn, requiresCompatibilities: .requiresCompatibilities, cpu: .cpu, memory: .memory'
+      NEW_DEF_JQ_FILTER="${NEW_DEF_JQ_FILTER}, ${FARGATE_JQ_FILTER}"
+    fi
+
     # Build new DEF with jq filter
     NEW_DEF=$(echo $DEF | jq "{${NEW_DEF_JQ_FILTER}}")
 

--- a/test.bats
+++ b/test.bats
@@ -281,6 +281,72 @@ EOF
   [ $output == $expected ]
 }
 
+@test "test createNewTaskDefJson with single container in definition for AWS Fargate" {
+  imageWithoutTag="121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo"
+  useImage="121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111"
+  TASK_DEFINITION=$(cat <<EOF
+{
+    "taskDefinition": {
+        "status": "ACTIVE",
+        "networkMode": "awsvpc",
+        "family": "app-task-def",
+        "requiresAttributes": [
+            {
+                "name": "com.amazonaws.ecs.capability.ecr-auth"
+            }
+        ],
+        "volumes": [],
+        "taskDefinitionArn": "arn:aws:ecs:us-east-1:121212345678:task-definition/app-task-def:123",
+        "containerDefinitions": [
+            {
+                "environment": [
+                    {
+                        "name": "KEY",
+                        "value": "value"
+                    }
+                ],
+                "name": "API",
+                "links": [],
+                "mountPoints": [],
+                "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1487623908",
+                "essential": true,
+                "portMappings": [
+                    {
+                        "protocol": "tcp",
+                        "containerPort": 80,
+                        "hostPort": 10080
+                    }
+                ],
+                "entryPoint": [],
+                "memory": 128,
+                "command": [
+                    "/data/run.sh"
+                ],
+                "cpu": 200,
+                "volumesFrom": []
+            }
+        ],
+        "revision": 123,
+        "executionRoleArn": "arn:aws:iam::121212345678:role/ecsTaskExecutionRole",
+        "compatibilities": [
+            "EC2",
+            "FARGATE"
+        ],
+        "requiresCompatibilities": [
+            "FARGATE"
+        ],
+        "cpu": "256",
+        "memory": "512"
+    }
+}
+EOF
+)
+  expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "networkMode": "awsvpc", "executionRoleArn": "arn:aws:iam::121212345678:role/ecsTaskExecutionRole", "requiresCompatibilities": [ "FARGATE" ], "cpu": "256", "memory": "512" }'
+  run createNewTaskDefJson
+  [ ! -z $status ]
+  [ $output == $expected ]
+}
+
 @test "test createNewTaskDefJson with multiple containers in definition" {
   imageWithoutTag="121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo"
   useImage="121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111"

--- a/test.bats
+++ b/test.bats
@@ -341,7 +341,7 @@ EOF
 }
 EOF
 )
-  expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "networkMode": "awsvpc", "executionRoleArn": "arn:aws:iam::121212345678:role/ecsTaskExecutionRole", "requiresCompatibilities": [ "FARGATE" ], "cpu": "256", "memory": "512" }'
+  expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "awsvpc", "executionRoleArn": "arn:aws:iam::121212345678:role/ecsTaskExecutionRole", "requiresCompatibilities": [ "FARGATE" ], "cpu": "256", "memory": "512" }'
   run createNewTaskDefJson
   [ ! -z $status ]
   [ $output == $expected ]


### PR DESCRIPTION
# WHAT IS THIS

AWS released new service "AWS Fargate" on November 30, 2017.

- https://aws.amazon.com/fargate/

This Pull Request goal is supporting AWS Fargate deployment, and solve this Issue ( https://github.com/silinternational/ecs-deploy/issues/127 ).

# ERROR

This error occurred by latest ecs-deploy.

```
An error occurred (InvalidParameterException) when calling the UpdateService operation: Task definition does not support launch_type FARGATE.
```

Because `Launch Types` ( parameter name is `requiresCompatibilities` ) added on Task Definition.

- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

Then `requiresCompatibilities` set value `FARGATE` or `EC2`, but `EC2` is default ECS.

- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html

# REQUIRE

If you deploy AWS Fargate using `aws-cli 1.14.0 or later` please.

# DETAILS

- Check `requiresCompatibilities` via Task Definition (JSON)
- If value equal `FARGATE` jq filters updated

Deployment is successful in my Fargate Cluster.

```
New task definition: arn:aws:ecs:us-east-1:111111111111:task-definition/xxx:13
Service updated successfully, new task definition running.
Waiting for service deployment to complete...
Service deployment successful.
```

# ANY HELP

I am little worried about deployment for other Fargate Cluster.

If someone has own Fargate Cluster, please check deployment with my version ??? 🙏 
~~( This is reason why this Pull Request is [WIP] . )~~

Thanks 👍 👍 👍 