### PR TITLE
Supported "--force-new-deployment" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Usage
                                             Max definitions causes all task revisions not matching criteria to be deregistered, even if they're created manually.
                                             Script will only perform deregistration if deployment succeeds.
         --enable-rollback             Rollback task definition if new version is not running before TIMEOUT
+        --force-new-deployment        Force a new deployment of the service. Default is false.
         -v | --verbose                Verbose output
              --version                Display the version
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -17,6 +17,7 @@ TAGONLY=""
 ENABLE_ROLLBACK=false
 AWS_CLI=$(which aws)
 AWS_ECS="$AWS_CLI --output json ecs"
+FORCE_NEW_DEPLOYMENT=false
 
 function usage() {
     cat <<EOM
@@ -38,7 +39,7 @@ Required arguments:
                                  Format: [domain][:port][/repo][/][image][:tag]
                                  Examples: mariadb, mariadb:latest, silintl/mariadb,
                                            silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
-    --aws-instance-profile  Use the IAM role associated with this instance
+    --aws-instance-profile       Use the IAM role associated with this instance
 
 Optional arguments:
     -a | --assume-role      ARN for AWS Role to assume for ecs-deploy operations.
@@ -50,6 +51,7 @@ Optional arguments:
     -to | --tag-only        New tag to apply to all images defined in the task (multi-container task). If provided this will override value specified in image name argument.
     --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
     --enable-rollback       Rollback task definition if new version is not running before TIMEOUT
+    --force-new-deployment  Force a new deployment of the service. Default is false.
     -v | --verbose          Verbose output
          --version          Display the version
 
@@ -145,7 +147,7 @@ function assertRequiredArgumentsSet() {
         echo "CLUSTER is required. You can pass the value using -c or --cluster"
         exit 7
     fi
-    if [ $IMAGE == false ]; then
+    if [ $IMAGE == false ] && [ $FORCE_NEW_DEPLOYMENT == false ]; then
         echo "IMAGE is required. You can pass the value using -i or --image"
         exit 8
     fi
@@ -323,6 +325,11 @@ function registerNewTaskDefinition() {
 function rollback() {
     echo "Rolling back to ${TASK_DEFINITION_ARN}"
     $AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --task-definition $TASK_DEFINITION_ARN > /dev/null
+}
+
+function updateServiceForceNewDeployment() {
+    echo 'Force a new deployment of the service'
+    $AWS_ECS update-service --cluster $CLUSTER --service $SERVICE --force-new-deployment > /dev/null
 }
 
 function updateService() {
@@ -530,6 +537,9 @@ if [ "$BASH_SOURCE" == "$0" ]; then
             --enable-rollback)
                 ENABLE_ROLLBACK=true
                 ;;
+            --force-new-deployment)
+                FORCE_NEW_DEPLOYMENT=true
+                ;;
             -v|--verbose)
                 VERBOSE=true
                 ;;
@@ -549,7 +559,6 @@ if [ "$BASH_SOURCE" == "$0" ]; then
         set -x
     fi
 
-
     # Check that required arguments are provided
     assertRequiredArgumentsSet
 
@@ -557,6 +566,12 @@ if [ "$BASH_SOURCE" == "$0" ]; then
         assumeRole
     fi
 
+    # Not required creation of new a task definition
+    if [ $FORCE_NEW_DEPLOYMENT == true ]; then
+        updateServiceForceNewDeployment
+        waitForGreenDeployment
+        exit 0
+    fi
 
     # Determine image name
     parseImageName
@@ -585,7 +600,6 @@ if [ "$BASH_SOURCE" == "$0" ]; then
     if [[ "$AWS_ASSUME_ROLE" != false ]]; then
         assumeRoleClean
     fi
-
 
     exit 0
 

--- a/test.bats
+++ b/test.bats
@@ -44,6 +44,7 @@ setup() {
   SERVICE=true
   CLUSTER=true
   IMAGE=false
+  FORCE_NEW_DEPLOYMENT=false
   run assertRequiredArgumentsSet
   [ $status -eq 8 ]
 }


### PR DESCRIPTION
# Issue

- https://github.com/silinternational/ecs-deploy/issues/137

# What is this

In February, ECS supported new option `--force-new-deployment`.

We can use this option to deploy with no service definition changes ( = force ) .

- https://docs.aws.amazon.com/cli/latest/reference/ecs/update-service.html

I supported `--force-new-deployment` for ecs-deploy.

![screencapture-ap-northeast-1-console-aws-amazon-ecs-home-2018-04-17-22_27_56](https://user-images.githubusercontent.com/1573290/38874641-88f90a0e-4293-11e8-8484-d7880d3fda7c.png)

# Log

It works with my ECS cluster 🎉 

```sh
$ ./ecs-deploy --cluster xxx --service-name yyy --force-new-deployment
Force a new deployment of the service
Waiting for service deployment to complete...
Service deployment successful.
```

# tests

```sh
$ docker-compose run --rm test
fetch http://dl-3.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz
WARNING: This apk-tools is OLD! Some packages might not function properly.
(1/1) Installing bats (0.4.0-r2)
Executing busybox-1.25.1-r1.trigger
OK: 65 MiB in 31 packages
1..33
ok 1 # skip (0) check that usage() returns string and exits with status code 20
ok 2 # skip (0) test assertRequiredArgumentsSet success
ok 3 # skip (0) test assertRequiredArgumentsSet status=5
ok 4 # skip (0) test assertRequiredArgumentsSet status=6
ok 5 # skip (0) test assertRequiredArgumentsSet status=7
ok 6 # skip (0) test assertRequiredArgumentsSet status=8
ok 7 # skip (0) test assertRequiredArgumentsSet status=9
ok 8 # skip (0) test parseImageName missing image name
ok 9 # skip (0) test parseImageName invalid image name 1
ok 10 # skip (0) test parseImageName invalid port
ok 11 # skip (0) test parseImageName root image no tag
ok 12 # skip (0) test parseImageName root image with tag
ok 13 # skip (0) test parseImageName repo image no tag
ok 14 # skip (0) test parseImageName repo image with tag
ok 15 # skip (0) test parseImageName repo multilevel image no tag
ok 16 # skip (0) test parseImageName repo multilevel image with tag
ok 17 # skip (0) test parseImageName domain plus repo image no tag
ok 18 # skip (0) test parseImageName domain plus repo image with tag
ok 19 # skip (0) test parseImageName domain plus repo multilevel image no tag
ok 20 # skip (0) test parseImageName domain plus repo multilevel image with tag
ok 21 # skip (0) test parseImageName domain plus port plus repo image no tag
ok 22 # skip (0) test parseImageName domain plus port plus repo image with tag
ok 23 # skip (0) test parseImageName domain plus port plus repo multilevel image no tag
ok 24 # skip (0) test parseImageName domain plus port plus repo multilevel image with tag
ok 25 # skip (0) test parseImageName domain plus port plus repo image with tag from var
ok 26 # skip (0) test parseImageName domain plus port plus repo multilevel image with tag from var
ok 27 # skip (0) test parseImageName using ecr style domain
ok 28 # skip (0) test parseImageName using ecr style image name and tag from var
ok 29 # skip (0) test createNewTaskDefJson with single container in definition
ok 30 # skip (0) test createNewTaskDefJson with single container in definition for AWS Fargate
ok 31 # skip (0) test createNewTaskDefJson with multiple containers in definition
ok 32 # skip (0) test parseImageName with tagonly option
ok 33 # skip (0) test createNewTaskDefJson with multiple containers in definition and replace only tags
```

Thanks, please review 👍 