### PR TITLE
 Add flag for using the latest task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Usage
                                             Script will only perform deregistration if deployment succeeds.
         --enable-rollback             Rollback task definition if new version is not running before TIMEOUT
         --force-new-deployment        Force a new deployment of the service. Default is false.
-        --skip-deployments-check      Skip deployments check for services that takes to long to drain old tasks
+        --skip-deployments-check      Skip deployments check for services that take too long to drain old tasks
         --run-task                    Run created task now. If you set this, service-name are not needed.
         -v | --verbose                Verbose output
              --version                Display the version

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -54,7 +54,7 @@ Optional arguments:
     --max-definitions            Number of Task Definition Revisions to persist before deregistering oldest revisions.
     --enable-rollback            Rollback task definition if new version is not running before TIMEOUT
     --force-new-deployment       Force a new deployment of the service. Default is false.
-    --skip-deployments-check     Skip deployments check for services that takes to long to drain old tasks
+    --skip-deployments-check     Skip deployments check for services that take too long to drain old tasks
     --run-task                   Run created task now. If you set this, service-name are not needed.
     -v | --verbose               Verbose output
          --version               Display the version


### PR DESCRIPTION
Merged in #125 to add flag for using the latest task definition

`--use-latest-task-def         Will use the most recently created task definition as it's base, rather than the last used.`