### PR TITLE
Add field Secrets on new task definition json generate. 

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -309,7 +309,7 @@ function createNewTaskDefJson() {
     fi
 
     # Default JQ filter for new task definition
-    NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
+    NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints, secrets: .secrets"
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.


### PR DESCRIPTION
AWS released new feature that integrate ECS with System Manager Service.

Now, we can pass stored parameters on each task definition.

https://docs.aws.amazon.com/pt_br/AmazonECS/latest/developerguide/specifying-sensitive-data.html

So, this plugin (ecs-deploy) not consider the new property **Secrets** included on task definition. 
.
.
.
      "ulimits": null,
      "dnsServers": null,
      "mountPoints": [],
      "workingDirectory": null,
      **"secrets": [
        {
          "valueFrom": "dbname-homolog",
          "name": "DATABASE"
        },
        {
          "valueFrom": "db-host-homolog",
          "name": "HOST"
        }
      ],**
.
.
.

I hope help...



