### PR TITLE
Use Alpine Linux 3.8 on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.8
 
 # Install packges needed
 RUN apk --no-cache add ca-certificates curl bash jq py2-pip && \

--- a/test.bats
+++ b/test.bats
@@ -279,7 +279,7 @@ EOF
   expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value * " } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "bridge" }'
   run createNewTaskDefJson
   [ ! -z $status ]
-  [ $(echo "$output" | jq) == $(echo "$expected" | jq) ]
+  [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }
 
 @test "test createNewTaskDefJson with single container in definition for AWS Fargate" {
@@ -345,7 +345,7 @@ EOF
   expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "awsvpc", "executionRoleArn": "arn:aws:iam::121212345678:role/ecsTaskExecutionRole", "requiresCompatibilities": [ "FARGATE" ], "cpu": "256", "memory": "512" }'
   run createNewTaskDefJson
   [ ! -z $status ]
-  [ $(echo "$output" | jq) == $(echo "$expected" | jq) ]
+  [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }
 
 @test "test createNewTaskDefJson with multiple containers in definition" {
@@ -429,7 +429,7 @@ EOF
   expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] }, { "environment": [ { "name": "KEY", "value": "value" } ], "name": "cache", "links": [], "mountPoints": [], "image": "redis:latest", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 6376, "hostPort": 10376 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "bridge" }'
   run createNewTaskDefJson
   [ ! -z $status ]
-  [ $(echo "$output" | jq) == $(echo "$expected" | jq) ]
+  [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }
 
 @test "test parseImageName with tagonly option" {
@@ -441,7 +441,7 @@ EOF
   run parseImageName
 
   [ ! -z $status ]
-  [ $(echo "$output" | jq) == $(echo "$expected" | jq) ]
+  [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }
 
 @test "test createNewTaskDefJson with multiple containers in definition and replace only tags" {
@@ -527,5 +527,5 @@ EOF
   run createNewTaskDefJson
   echo $output
   [ ! -z $status ]
-  [ $(echo "$output" | jq) == $(echo "$expected" | jq) ]
+  [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }


### PR DESCRIPTION
Hi @fillup 😄 

# What is this

Alpine Linux 3.5 is already NOT supported.
( End of Support : 2018-11-01 )

- https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

So, I updated to Alpine Linux 3.8 (latest).

- https://hub.docker.com/r/_/alpine/

Some tests are failed with Alpine Linux 3.8 because `[ ]` and `jq` syntax are NOT correct.
So, I fixed it together 👍 

```sh
$ docker-compose run --rm test

...

not ok 29 test createNewTaskDefJson with single container in definition
# (in test file test.bats, line 282)
#   `[ $(echo "$output" | jq) == $(echo "$expected" | jq) ]' failed with status 2
# /tmp/bats.11.src: line 282: [: too many arguments
not ok 30 test createNewTaskDefJson with single container in definition for AWS Fargate
# (in test file test.bats, line 348)
#   `[ $(echo "$output" | jq) == $(echo "$expected" | jq) ]' failed with status 2
# /tmp/bats.11.src: line 348: [: too many arguments
not ok 31 test createNewTaskDefJson with multiple containers in definition
# (in test file test.bats, line 432)
#   `[ $(echo "$output" | jq) == $(echo "$expected" | jq) ]' failed with status 2
# /tmp/bats.11.src: line 432: [: too many arguments
ok 32 test parseImageName with tagonly option # skip 0
not ok 33 test createNewTaskDefJson with multiple containers in definition and replace only tags
# (in test file test.bats, line 530)
#   `[ $(echo "$output" | jq) == $(echo "$expected" | jq) ]' failed with status 2
# { "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:newtag", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] }, { "environment": [ { "name": "KEY", "value": "value" } ], "name": "cache", "links": [], "mountPoints": [], "image": "redis:newtag", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 6376, "hostPort": 10376 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "bridge" }
# /tmp/bats.11.src: line 530: [: too many arguments
```

# tests

```sh
$ docker-compose run --rm test
fetch http://dl-3.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/1) Installing bats (1.1.0-r0)
Executing busybox-1.28.4-r1.trigger
OK: 67 MiB in 34 packages
1..33
ok 1 check that usage() returns string and exits with status code 20 # skip 0
ok 2 test assertRequiredArgumentsSet success # skip 0
ok 3 test assertRequiredArgumentsSet status=5 # skip 0
ok 4 test assertRequiredArgumentsSet status=6 # skip 0
ok 5 test assertRequiredArgumentsSet status=7 # skip 0
ok 6 test assertRequiredArgumentsSet status=8 # skip 0
ok 7 test assertRequiredArgumentsSet status=9 # skip 0
ok 8 test parseImageName missing image name # skip 0
ok 9 test parseImageName invalid image name 1 # skip 0
ok 10 test parseImageName invalid port # skip 0
ok 11 test parseImageName root image no tag # skip 0
ok 12 test parseImageName root image with tag # skip 0
ok 13 test parseImageName repo image no tag # skip 0
ok 14 test parseImageName repo image with tag # skip 0
ok 15 test parseImageName repo multilevel image no tag # skip 0
ok 16 test parseImageName repo multilevel image with tag # skip 0
ok 17 test parseImageName domain plus repo image no tag # skip 0
ok 18 test parseImageName domain plus repo image with tag # skip 0
ok 19 test parseImageName domain plus repo multilevel image no tag # skip 0
ok 20 test parseImageName domain plus repo multilevel image with tag # skip 0
ok 21 test parseImageName domain plus port plus repo image no tag # skip 0
ok 22 test parseImageName domain plus port plus repo image with tag # skip 0
ok 23 test parseImageName domain plus port plus repo multilevel image no tag # skip 0
ok 24 test parseImageName domain plus port plus repo multilevel image with tag # skip 0
ok 25 test parseImageName domain plus port plus repo image with tag from var # skip 0
ok 26 test parseImageName domain plus port plus repo multilevel image with tag from var # skip 0
ok 27 test parseImageName using ecr style domain # skip 0
ok 28 test parseImageName using ecr style image name and tag from var # skip 0
ok 29 test createNewTaskDefJson with single container in definition # skip 0
ok 30 test createNewTaskDefJson with single container in definition for AWS Fargate # skip 0
ok 31 test createNewTaskDefJson with multiple containers in definition # skip 0
ok 32 test parseImageName with tagonly option # skip 0
ok 33 test createNewTaskDefJson with multiple containers in definition and replace only tags # skip 0
```

Thanks 🎅 