### PR TITLE
[WIP] Supported SSM Parameter Store

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -309,7 +309,7 @@ function createNewTaskDefJson() {
     fi
 
     # Default JQ filter for new task definition
-    NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
+    NEW_DEF_JQ_FILTER="executionRoleArn: .executionRoleArn, family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.
@@ -324,7 +324,7 @@ function createNewTaskDefJson() {
     # Updated jq filters for AWS Fargate
     REQUIRES_COMPATIBILITIES=$(echo "${DEF}" | jq -r '. | select(.requiresCompatibilities != null) | .requiresCompatibilities[]')
     if [[ "${REQUIRES_COMPATIBILITIES}" == 'FARGATE' ]]; then
-      FARGATE_JQ_FILTER='executionRoleArn: .executionRoleArn, requiresCompatibilities: .requiresCompatibilities, cpu: .cpu, memory: .memory'
+      FARGATE_JQ_FILTER='requiresCompatibilities: .requiresCompatibilities, cpu: .cpu, memory: .memory'
       NEW_DEF_JQ_FILTER="${NEW_DEF_JQ_FILTER}, ${FARGATE_JQ_FILTER}"
     fi
 


### PR DESCRIPTION
This is still WIP ⚠️ 

# New

ECS supported SSM Parameter Store with task definition.

- [AWS Launches Secrets Support for Amazon Elastic Container Service](https://aws.amazon.com/jp/about-aws/whats-new/2018/11/aws-launches-secrets-support-for-amazon-elastic-container-servic/)
- [Specifying Sensitive Data - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)

# Task Definition diff

If we use this function, task definition added `secrets` section like this.
( this is snippet 🐱)

```json
{
  "executionRoleArn": "arn:aws:iam::111111111111:role/ecsTaskExecutionRole",
  "containerDefinitions": [
    {
      "secrets": [
        {
          "valueFrom": "xxx",
          "name": "XXX"
        }
      ]
    }
  ],
}
```

Because `secrets` is children of `containerDefinitions`, we don't need additional filter 👌 

# executionRoleArn Dependency

If we use `secrets`, `executionRoleArn` is need together.
So, I added `executionRoleArn` to default jq filter. 

>An error occurred (ClientException) when calling the RegisterTaskDefinition operation: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.

# Requirements

These are important requirements.

- Update latest AWS CLI ( I guess 1.16.56 or later )
- Update latest ECS Container Agent ( 1.22.0 or later )
- Use ECS
    - Currently, Fargate is not supported SSM Parameter Store

>This feature is not yet supported for tasks using the Fargate launch type.
>https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html

# Worked Good

```sh
$ ./ecs-deploy --cluster xxx --service-name yyy --image ccc
```

# TODO

- [ ] Add Specs