### PR TITLE
Support requires compatibilities both ec2 and fargate

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -323,7 +323,7 @@ function createNewTaskDefJson() {
 
     # Updated jq filters for AWS Fargate
     REQUIRES_COMPATIBILITIES=$(echo "${DEF}" | jq -r '. | select(.requiresCompatibilities != null) | .requiresCompatibilities[]')
-    if [[ "${REQUIRES_COMPATIBILITIES}" == 'FARGATE' ]]; then
+    if `echo ${REQUIRES_COMPATIBILITIES[@]} | grep -q "FARGATE"`; then
       FARGATE_JQ_FILTER='executionRoleArn: .executionRoleArn, requiresCompatibilities: .requiresCompatibilities, cpu: .cpu, memory: .memory'
       NEW_DEF_JQ_FILTER="${NEW_DEF_JQ_FILTER}, ${FARGATE_JQ_FILTER}"
     fi


### PR DESCRIPTION
ISSUE: When need requires compatibilities both ec2 and fargate, ecs-deploy cannot create new task definition with fargate.

FIX: Check requires compatibilities contains fargate.