### PR TITLE
add executionRoleArn into NEW_DEF_JQ_FILTER

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -313,7 +313,7 @@ function createNewTaskDefJson() {
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.
-    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints)
+    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn)
     for i in "${CONDITIONAL_OPTIONS[@]}"; do
       re=".*${i}.*"
       if [[ "$DEF" =~ $re ]]; then

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -309,7 +309,7 @@ function createNewTaskDefJson() {
     fi
 
     # Default JQ filter for new task definition
-    NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
+    NEW_DEF_JQ_FILTER="executionRoleArn: .executionRoleArn, ffamily: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -309,7 +309,7 @@ function createNewTaskDefJson() {
     fi
 
     # Default JQ filter for new task definition
-    NEW_DEF_JQ_FILTER="executionRoleArn: .executionRoleArn, ffamily: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
+    NEW_DEF_JQ_FILTER="executionRoleArn: .executionRoleArn, family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions, placementConstraints: .placementConstraints"
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.


### PR DESCRIPTION
If "executionRoleArn" is specified for Task, ecs-deploy will result in an error and a filter will be added because it failed.

```
An error occurred (ClientException) when calling the RegisterTaskDefinition operation: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.
```