### PR TITLE
changing comparisons to avoid unbound errors and problems caused by undefined-guard

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -217,6 +217,12 @@ function parseImageName() {
           exit 12
         fi
         tag=${BASH_REMATCH[2]}
+
+        # for root level repo, initialize unused variables for checks when rebuilding image below
+        domain=""
+        port=""
+        repo=""
+
       else
         echo "Unable to parse image name: $IMAGE, check the format and try again"
         exit 13
@@ -236,28 +242,27 @@ function parseImageName() {
     fi
 
     # Reassemble image name
+    useImage=""
     if [[ "x$TAGONLY" == "x" ]]; then
 
-      if [[ ! -z ${domain+undefined-guard} ]]; then
+      if [[ ! -z "$domain" ]]; then
         useImage="$domain"
       fi
-      if [[ ! -z ${port+undefined-guard} ]]; then
+      if [[ ! -z "$port" ]]; then
         useImage="$useImage:$port"
       fi
-      if [[ ! -z ${repo+undefined-guard} ]]; then
-       if [[ ! "x$repo" == "x" ]]; then
+      if [[ ! -z "$repo" ]]; then
         useImage="$useImage/$repo"
-       fi
       fi
-      if [[ ! -z ${img+undefined-guard} ]]; then
-        if [[ "x${useImage+undefined-guard}" == "x" ]]; then
+      if [[ ! -z "$img" ]]; then
+        if [[ -z "$useImage" ]]; then
           useImage="$img"
         else
           useImage="$useImage/$img"
         fi
       fi
       imageWithoutTag="$useImage"
-      if [[ ! -z ${tag+undefined-guard} ]]; then
+      if [[ ! -z "$tag" ]]; then
         useImage="$useImage:$tag"
       fi
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -206,6 +206,10 @@ function parseImageName() {
         fi
       else
         tag=${BASH_REMATCH[1]}
+        domain=""
+        port=""
+        repo=""
+        img=""
       fi
     else
       # check if using root level repo with format like mariadb or mariadb:latest


### PR DESCRIPTION
After merging #173 the unit tests started failing. The addition of `+undefined-guard` to `port` in testing caused the addition of a colon to the repo name in an invalid position. After troubleshooting I found it was caused when the image name in use was a "root level" image and therefore several variables were not being defined/initialized, namely `domain`, `port`, and `repo`. Now I'm initializing them to an empty string so a simple test without the `undefined-guard` works properly.

All unit tests are now passing and manually running ecs-deploy with each kind of matching image name are working without throwing unbound variable errors as reported in #171. 

Further info on comparison method: https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash/13864829#13864829