### PR TITLE
Allow underscores in repository names.

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -213,7 +213,7 @@ function parseImageName() {
       fi
     else
       # check if using root level repo with format like mariadb or mariadb:latest
-      rootRepoRegex="^([a-zA-Z0-9\-]+):?([a-zA-Z0-9\.\-]+)?$"
+      rootRepoRegex="^([a-zA-Z0-9\-]+):?([a-zA-Z0-9\.\-_]+)?$"
       if [[ $IMAGE =~ $rootRepoRegex ]]; then
         img=${BASH_REMATCH[1]}
         if [[ "x$img" == "x" ]]; then


### PR DESCRIPTION
Repository names may contain underscores, but they can't start with one.