### PR TITLE
Update image tag to be same as environment

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -615,7 +615,9 @@ if [ "$BASH_SOURCE" == "$0" ]; then
     # Not required creation of new a task definition
     if [ $FORCE_NEW_DEPLOYMENT == true ]; then
         updateServiceForceNewDeployment
-        waitForGreenDeployment
+        if [[ $SKIP_DEPLOYMENTS_CHECK != true ]]; then
+          waitForGreenDeployment
+        fi
         exit 0
     fi
 


### PR DESCRIPTION
The `--skip-deployments-check` flag will do nothing without this change when `--force-new-deploy` is used. 