### PR TITLE
Revert "Replace image name, even if repository was changed"

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -308,7 +308,8 @@ function createNewTaskDefJson() {
     # + Filter the def
     if [[ "x$TAGONLY" == "x" ]]; then
       DEF=$( echo "$TASK_DEFINITION" \
-            | sed -e 's~"image":.*,~"image": "'${useImage}'",~' \
+            | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
+            | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
             | jq '.taskDefinition' )
     else
       DEF=$( echo "$TASK_DEFINITION" \


### PR DESCRIPTION
Reverts silinternational/ecs-deploy#204

This change broke the case where a task definition had multiple container definitions using different images. Thankfully unit tests identified this, unfortunately I didn't run them before the merge. 