### PR TITLE
Add memory to conditional options for all launch types

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -353,7 +353,7 @@ function createNewTaskDefJson() {
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.
-    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn)
+    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn memory)
     for i in "${CONDITIONAL_OPTIONS[@]}"; do
       re=".*${i}.*"
       if [[ "$DEF" =~ $re ]]; then


### PR DESCRIPTION
This PR adds the `memory` parameter to the conditional options. This parameter can be set in either fargate or ec2 launch types and should always be included in the copied task definition if it is present.