### PR TITLE
Change variable $TASK_DEFINITION to $taskDefinition (`--task-definition-file` option not working)

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -339,7 +339,7 @@ function createNewTaskDefJson() {
     # + Update definition to use new image name
     # + Filter the def
     if [[ "x$TAGONLY" == "x" ]]; then
-      DEF=$( echo "$TASK_DEFINITION" \
+      DEF=$( echo "$taskDefinition" \
             | sed -e 's~"image":.*'"${imageWithoutTag}"'.*,~"image": "'"${useImage}"'",~g' \
             | jq '.taskDefinition' )
     else


### PR DESCRIPTION
Hi

When we use `--task-definition-file`, the content of the file specified by the `--task-definition-file` option is not used,
because of the following situation.

```sh
    if [ $TASK_DEFINITION_FILE == false ]; then
        taskDefinition="$TASK_DEFINITION"
    else
        taskDefinition="$(cat $TASK_DEFINITION_FILE)"
    fi

    # Get a JSON representation of the current task definition
    # + Update definition to use new image name
    # + Filter the def
    if [[ "x$TAGONLY" == "x" ]]; then

      DEF=$( echo "$TASK_DEFINITION" \
            | sed -e 's~"image":.*'"${imageWithoutTag}"'.*,~"image": "'"${useImage}"'",~g' \
            | jq '.taskDefinition' )
```

Please confirm.

Yohei