### PR TITLE
Add --copy-task-definition-tags argument to copy task definition tags to new revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage
         --network-configuration       The network configuration for the task. This parameter is required for task definitions that use
                                           the awsvpc network mode to receive their own elastic network interface, and it is not supported
                                           for other network modes. (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
+        --copy-task-definition-tags   Copy the existing task definition tags to the new task definition revision
         -v | --verbose                Verbose output
              --version                Display the version
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -25,6 +25,8 @@ RUN_TASK=false
 RUN_TASK_LAUNCH_TYPE=false
 RUN_TASK_NETWORK_CONFIGURATION=false
 RUN_TASK_WAIT_FOR_SUCCESS=false
+TASK_DEFINITION_TAGS=false
+COPY_TASK_DEFINITION_TAGS=false
 
 function usage() {
     cat <<EOM
@@ -68,6 +70,7 @@ Optional arguments:
     --network-configuration      The network configuration for the task. This parameter is required for task definitions that use
                                        the awsvpc network mode to receive their own elastic network interface, and it is not supported
                                        for other network modes. (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
+    --copy-task-definition-tags  Copy the existing task definition tags to the new task definition revision
     -v | --verbose               Verbose output
          --version               Display the version
 
@@ -324,7 +327,15 @@ function getCurrentTaskDefinition() {
       # Get current task definition arn from family[:revision] (or arn)
       TASK_DEFINITION_ARN=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION | jq -r .taskDefinition.taskDefinitionArn`
     fi
-    TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
+
+    # Get task definition using current task definition arn
+    # If we're copying task definition tags to the new revision, also get current task definition tags
+    if [[ "$COPY_TASK_DEFINITION_TAGS" == true ]]; then
+      TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN --include TAGS`
+      TASK_DEFINITION_TAGS=$( echo "$TASK_DEFINITION" | jq ".tags" )
+    else
+      TASK_DEFINITION=`$AWS_ECS describe-task-definition --task-def $TASK_DEFINITION_ARN`
+    fi
 }
 
 function createNewTaskDefJson() {
@@ -383,7 +394,11 @@ function createNewTaskDefJson() {
 
 function registerNewTaskDefinition() {
     # Register the new task definition, and store its ARN
-    NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$NEW_DEF" | jq -r .taskDefinition.taskDefinitionArn`
+    if [[ "$COPY_TASK_DEFINITION_TAGS" == true && "$TASK_DEFINITION_TAGS" != false ]]; then
+      NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$NEW_DEF" --tags "$TASK_DEFINITION_TAGS" | jq -r .taskDefinition.taskDefinitionArn`
+    else
+      NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$NEW_DEF" | jq -r .taskDefinition.taskDefinitionArn`
+    fi
 }
 
 function rollback() {
@@ -564,7 +579,7 @@ function runTask {
     fi
   fi
 
-  
+
 
   echo "Task $TASK_ARN executed successfully!"
   exit 0
@@ -690,6 +705,9 @@ if [ "$BASH_SOURCE" == "$0" ]; then
             --network-configuration)
                 RUN_TASK_NETWORK_CONFIGURATION="$2"
                 shift
+                ;;
+            --copy-task-definition-tags)
+                COPY_TASK_DEFINITION_TAGS=true
                 ;;
             -v|--verbose)
                 VERBOSE=true


### PR DESCRIPTION
This allows the option to copy the existing task definition tags over to new revisions created using `ecs-deploy` by including a `--copy-task-definition-tags` argument to the command. 

We recently came across this issue as the initial task definitions created via Terraform were being tagged but subsequent revisions created via the ecs-deploy script didn't have the original tags carried over.

I noticed there was an existing issue mentioning this as well. Posting a PR on how we added this functionality on our end in case this is helpful to others as this resolves https://github.com/silinternational/ecs-deploy/issues/212