### PR TITLE
container: standard PATH location for the script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ RUN apk --no-cache add ca-certificates curl bash jq py3-pip && \
     pip install awscli
 
 COPY ecs-deploy /usr/local/bin/ecs-deploy
-RUN chmod a+x /usr/local/bin/ecs-deploy && \
-    ln -s /usr/local/bin/ecs-deploy /ecs-deploy
+RUN ln -s /usr/local/bin/ecs-deploy /ecs-deploy
 
 COPY test.bats /test.bats
 COPY run-tests.sh /run-tests.sh
-RUN chmod a+x /run-tests.sh
 
-ENTRYPOINT ["/usr/local/bin/ecs-deploy"]
+ENTRYPOINT ["ecs-deploy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-# Install packges needed
+# Install required packages
 RUN apk --no-cache add ca-certificates curl bash jq py3-pip && \
     pip install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ FROM alpine:3.13
 RUN apk --no-cache add ca-certificates curl bash jq py3-pip && \
     pip install awscli
 
-COPY ecs-deploy /ecs-deploy
-RUN chmod a+x /ecs-deploy
+COPY ecs-deploy /usr/local/bin/ecs-deploy
+RUN chmod a+x /usr/local/bin/ecs-deploy && \
+    ln -s /usr/local/bin/ecs-deploy /ecs-deploy
 
 COPY test.bats /test.bats
 COPY run-tests.sh /run-tests.sh
 RUN chmod a+x /run-tests.sh
 
-ENTRYPOINT ["/ecs-deploy"]
+ENTRYPOINT ["/usr/local/bin/ecs-deploy"]


### PR DESCRIPTION
In order to simplify the execution in a shell (such as in CI systems), the executable should be located in a standard UNIX `PATH` location. I picked `/usr/local/bin` in order to specify the executable is not coming from a standard package.

* link `/ecs-deploy` to the new location for compatibility in case some people are already using the image with this location of the script.
* remove some `RUN` command as the files are already executable in git, therefore the copy during the build will keep those `x` flags.
* minor typo in comment

It might be issue faced by the user in #124.

Currently, this fails:
```console
$ docker run -it --rm --entrypoint "" silintl/ecs-deploy:3.10.0 ecs-deploy --version
docker: Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "ecs-deploy": executable file not found in $PATH: unknown.
```

With the change:
```console
$ docker run -it --rm --entrypoint "" ecs-deploy:local ecs-deploy --version
3.10.0
```