### PR TITLE
add runtimePlatform to CONDITIONAL_OPTIONS

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -375,7 +375,7 @@ function createNewTaskDefJson() {
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.
-    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn)
+    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn runtimePlatform)
     for i in "${CONDITIONAL_OPTIONS[@]}"; do
       re=".*${i}.*"
       if [[ "$DEF" =~ $re ]]; then


### PR DESCRIPTION
ecs-deploy is overwriting runtimePlatform containing operatingSystemFamily and cpuArchitecture