### PR TITLE
Fix missing gh action input for force-new-deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,8 @@ inputs:
   use_latest_task_def:
     description: 'Will use the most recently created task definition as its base, rather than the last used.'
     required: false
+  force_new_deployment_cmd:
+    description: '--force-new-deployment'
   force_new_deployment:
     description: 'Force a new deployment of the service.'
     required: false


### PR DESCRIPTION
It was missing the command input `force_new_deployment_cmd` so this PR adds it

```
Warning: Unexpected input(s) 'force_new_deployment_cmd', valid inputs are ['entryPoint', 'args', 'aws_access_key_cmd', 'aws_access_key', 'aws_secret_key_cmd', 'aws_secret_key', 'service_name_cmd', 'service_name', 'task_definition_cmd', 'task_definition', 'region_cmd', 'region', 'profile_cmd', 'profile', 'cluster_cmd', 'cluster', 'image_cmd', 'image', 'aws_assume_role', 'desired_count', 'min_cmd', 'min', 'max_cmd', 'max', 'timeout_cmd', 'timeout', 'tag_env_var', 'tag_only', 'max_definitions_cmd', 'max_definitions', 'enable_rollback_cmd', 'enable_rollback', 'use_latest_task_def_cmd', 'use_latest_task_def', 'force_new_deployment', 'run_task', 'skip_deployments_check_cmd', 'skip_deployments_check', 'verbose']
```