### PR TITLE
fix: replace image uri for non TAGONLY images

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -362,7 +362,7 @@ function createNewTaskDefJson() {
     # + Filter the def
     if [[ "x$TAGONLY" == "x" ]]; then
       DEF=$( echo "$taskDefinition" \
-            | sed -e 's~"image":.*'"${imageWithoutTag}"'.*,~"image": "'"${useImage}"'",~g' \
+            | sed -e 's~"image":.*'".*"'.*,~"image": "'"${useImage}"'",~g' \
             | jq '.taskDefinition' )
     else
       DEF=$( echo "$taskDefinition" \


### PR DESCRIPTION

For deployments which don't contain TAGONLY enable, it will replace image url, which is helpful for conditions where we have services ready but inital image has to be pushed by CI/CD in which cast we can create initial task defiantion with random docker images eg: "nginx:latest", and let CI script replace taskdefination image with ECR based app/project image.

Currently script only replaces image tag for both tagonly flag enabled or disabled cases. this issue will get fixed by this