### PR TITLE
tag-only supports container names which should be updated (others will stay intact)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Usage
                                       Note: This number must be 1 or higher (i.e. keep only the current revision ACTIVE).
                                             Max definitions causes all task revisions not matching criteria to be deregistered, even if they're created manually.
                                             Script will only perform deregistration if deployment succeeds.
+        
+        -- tag_only_container_names   This parameter can work when --tag-only is enabled. It passes specfic container names which should be updated with the new tag and other containers will not be updated with the provided tag   
         --task-definition-file        File used as task definition to deploy
         --enable-rollback             Rollback task definition if new version is not running before TIMEOUT
         --use-latest-task-def         Will use the most recently created task definition as it's base, rather than the last used.

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,12 @@ inputs:
   tag_only:
     description: 'New tag to apply to all images defined in the task (multi-container task). If provided this will override value specified in image name argument.'
     required: false
+  tag_only_container_names_cmd:
+    description: '--tag_only_container_names'
+    required: false
+  tag_only_container_names:
+    description: 'New tag to apply to fixed images defined in the task (multi-container task).'
+    required: false
   max_definitions_cmd:
     description: '--max-definition'
   max_definitions:
@@ -137,6 +143,7 @@ runs:
     '${{ inputs.timeout_cmd }}', '${{ inputs.timeout }}',
     '${{ inputs.tag_env_var_cmd }}', '${{ inputs.tag_env_var }}',
     '${{ inputs.tag_only_cmd }}', '${{ inputs.tag_only }}',
+    '${{ inputs.tag_only_container_names_cmd }}', '${{ inputs.tag_only_container_names }}',
     '${{ inputs.use_latest_task_def_cmd }}', '${{ inputs.use_latest_task_def }}',
     '${{ inputs.max_definitions_cmd }}', '${{ inputs.max_definitions }}'
   ]

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -15,6 +15,7 @@ TIMEOUT=90
 VERBOSE=false
 TAGVAR=false
 TAGONLY=""
+TAGONLYCONTAINERNAMES=""
 ENABLE_ROLLBACK=false
 USE_MOST_RECENT_TASK_DEFINITION=false
 AWS_CLI=$(which aws)
@@ -28,6 +29,7 @@ RUN_TASK_NETWORK_CONFIGURATION=false
 RUN_TASK_WAIT_FOR_SUCCESS=false
 TASK_DEFINITION_TAGS=false
 COPY_TASK_DEFINITION_TAGS=false
+FOR_EXAMPLE=""
 
 function usage() {
     cat <<EOM
@@ -61,6 +63,7 @@ Optional arguments:
                                        specified in image name argument.
     -to | --tag-only             New tag to apply to all images defined in the task (multi-container task).
                                        If provided this will override value specified in image name argument.
+    -toc | --tag_only_container_names New tag to apply to fixed images defined in the task (multi-container task).
     --max-definitions            Number of Task Definition Revisions to persist before deregistering oldest revisions.
     --task-definition-file       File used as task definition to deploy
     --enable-rollback            Rollback task definition if new version is not running before TIMEOUT
@@ -360,14 +363,24 @@ function createNewTaskDefJson() {
     # Get a JSON representation of the current task definition
     # + Update definition to use new image name
     # + Filter the def
+
     if [[ "x$TAGONLY" == "x" ]]; then
-      DEF=$( echo "$taskDefinition" \
-            | sed -e 's~"image":.*'"${imageWithoutTag}"'.*,~"image": "'"${useImage}"'",~g' \
-            | jq '.taskDefinition' )
+        DEF=$( echo "$taskDefinition" \
+              | sed -e 's~"image":.*'"${imageWithoutTag}"'.*,~"image": "'"${useImage}"'",~g' \
+              | jq '.taskDefinition' )
+    elif [[ "x$TAGONLYCONTAINERNAMES" == "x" ]]; then
+        DEF=$( echo "$taskDefinition" \
+              | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" \
+              | jq '.taskDefinition' )
     else
-      DEF=$( echo "$taskDefinition" \
-            | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" \
-            | jq '.taskDefinition' )
+        IFS=',' read -a myarray <<< $TAGONLYCONTAINERNAMES
+        for (( c=0; c<${#myarray[@]}; c++ ))
+          do
+              FOR_EXAMPLE+="/${myarray[c]}/s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|;"
+          done
+        DEF=$( echo "$taskDefinition" \
+                    | sed -e "${FOR_EXAMPLE}" \
+                    | jq '.taskDefinition' )
     fi
 
     # Default JQ filter for new task definition
@@ -685,6 +698,10 @@ if [ "$BASH_SOURCE" == "$0" ]; then
                 ;;
             -to|--tag-only)
                 TAGONLY="$2"
+                shift
+                ;;
+            -toc|--tag_only_container_names)
+                TAGONLYCONTAINERNAMES="$2"
                 shift
                 ;;
             --max-definitions)


### PR DESCRIPTION
Now, we `--tag-only` supports updating specific image tags instead of all the images.