### PR TITLE
Release 3.10.7

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.6"
+VERSION="3.10.7"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.5"
+VERSION="3.10.6"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false


### PR DESCRIPTION
### Fixed
- Preserve value of `runtimePlatform` (containing operatingSystemFamily and cpuArchitecture)