### PR TITLE
BUG: copy-task-definition-tags error when task def has no tags

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -405,7 +405,7 @@ function createNewTaskDefJson() {
 
 function registerNewTaskDefinition() {
     # Register the new task definition, and store its ARN
-    if [[ "$COPY_TASK_DEFINITION_TAGS" == true && "$TASK_DEFINITION_TAGS" != false ]]; then
+    if [[ "$COPY_TASK_DEFINITION_TAGS" == true && "$TASK_DEFINITION_TAGS" != false && "$TASK_DEFINITION_TAGS" != "[]" ]]; then
       NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$NEW_DEF" --tags "$TASK_DEFINITION_TAGS" | jq -r .taskDefinition.taskDefinitionArn`
     else
       NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$NEW_DEF" | jq -r .taskDefinition.taskDefinitionArn`


### PR DESCRIPTION
### Description

This small fix allows a smooth interaction with deploys of services that might have or not have tags.

All credit goes to @oliveirafilipe for providing the solution in this issue: https://github.com/silinternational/ecs-deploy/issues/232

I've tested the fix, with the argument in place, bot task definitions with and without tags are being deployed smoothly.