### PR TITLE
Release 3.10.10 - move the script into the PATH

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.8"
+VERSION="3.10.10"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false


### PR DESCRIPTION
The `ecs-deploy` script is now located at `/usr/local/bin` in the Docker image, with a symlink at the original location (`/`).

_Note: this change was effective in 3.10.9 but the script self-reported version number was not updated in that version._