### PR TITLE
Fix gha skip-deployments-check argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,5 +151,6 @@ runs:
     '${{ inputs.use_latest_task_def_cmd }}', '${{ inputs.use_latest_task_def }}',
     '${{ inputs.max_definitions_cmd }}', '${{ inputs.max_definitions }}',
     '${{ inputs.run_task_cmd }}', '${{ inputs.run_task }}',
-    '${{ inputs.wait_for_success_cmd }}', '${{ inputs.wait_for_success }}'
+    '${{ inputs.wait_for_success_cmd }}', '${{ inputs.wait_for_success }}',
+    '${{ inputs.skip_deployments_check_cmd }}', '${{ inputs.skip_deployments_check }}'
   ]


### PR DESCRIPTION
I've added the missing `skip_deployments_check_cmd` and `skip_deployments_check` arguments so that `skip-deployments-check` can be passed down from the gha to the ecs-deploy command.