### PR TITLE
Releaese 3.10.11

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,5 +151,6 @@ runs:
     '${{ inputs.use_latest_task_def_cmd }}', '${{ inputs.use_latest_task_def }}',
     '${{ inputs.max_definitions_cmd }}', '${{ inputs.max_definitions }}',
     '${{ inputs.run_task_cmd }}', '${{ inputs.run_task }}',
-    '${{ inputs.wait_for_success_cmd }}', '${{ inputs.wait_for_success }}'
+    '${{ inputs.wait_for_success_cmd }}', '${{ inputs.wait_for_success }}',
+    '${{ inputs.skip_deployments_check_cmd }}', '${{ inputs.skip_deployments_check }}'
   ]

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.10"
+VERSION="3.10.11"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.8"
+VERSION="3.10.10"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false


### PR DESCRIPTION
### Fixed
- Added the missing `skip_deployments_check_cmd` and `skip_deployments_check` arguments so that `skip-deployments-check` can be passed down from the gha to the ecs-deploy command.