### PR TITLE
Preserve ephemeral storage configuration in task definition

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -375,7 +375,7 @@ function createNewTaskDefJson() {
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.
-    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn runtimePlatform)
+    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn runtimePlatform ephemeralStorage)
     for i in "${CONDITIONAL_OPTIONS[@]}"; do
       re=".*${i}.*"
       if [[ "$DEF" =~ $re ]]; then


### PR DESCRIPTION
The `ephemeralStorage` task definition parameter for Fargate tasks was not being preserved by ecs-deploy, causing unexpected disk space problems after deployments. This fixes that.