### PR TITLE
Release 3.10.15 - Fix version number in script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+### Added
+- 
+
+### Changed (non-breaking)
+-
+
+### Changed (BREAKING)
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+- 
+
+### Security
+-
+
+---
+
+### Feature PR Checklist
+- [ ] Documentation (README, local.env.dist, etc.)
+- [ ] Unit tests created or updated (see `test.bats` file)
+
+### Release PR Checklist
+- [ ] Update version number in `ecs-deploy` script
+- [ ] Give the PR a title of `Release _._._ - Summary of change` (using whatever
+      the new version number is, plus a succinct summary of what changed)

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.13"
+VERSION="3.10.15"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false


### PR DESCRIPTION
### Fixed
- Fix version number in `ecs-deploy` script itself
- Add pull request (PR) template to help us remember this step in the future

---

### Release PR Checklist
- [x] Update version number in `ecs-deploy` script
- [x] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
