### PR TITLE
Feature/remove silintl mariadb

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Usage
         -n | --service-name           Name of service to deploy
         -i | --image                  Name of Docker image to run, ex: repo/image:latest
                                       Format: [domain][:port][/repo][/][image][:tag]
-                                      Examples: mariadb, mariadb:latest, silintl/mariadb,
-                                                silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
+                                      Examples: mariadb, mariadb:latest, private.registry.com:8000/repo/image:tag
 
     Optional arguments:
         -a | --aws-assume-role        ARN for AWS Role to assume for ecs-deploy operations.

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -47,8 +47,7 @@ Required arguments:
     -c | --cluster               Name of ECS cluster
     -i | --image                 Name of Docker image to run, ex: repo/image:latest
                                  Format: [domain][:port][/repo][/][image][:tag]
-                                 Examples: mariadb, mariadb:latest, silintl/mariadb,
-                                           silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
+                                 Examples: mariadb, mariadb:latest, private.registry.com:8000/repo/image:tag
     --aws-instance-profile       Use the IAM role associated with this instance
 
 Optional arguments:


### PR DESCRIPTION
### Removed
- README and ecs-deploy no longer list silintl/mariadb as an example
