### PR TITLE
Release 3.10.16 - allow underscores in tag names

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+### Added
+- 
+
+### Changed (non-breaking)
+-
+
+### Changed (BREAKING)
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+- 
+
+### Security
+-
+
+---
+
+### Feature PR Checklist
+- [ ] Documentation (README, local.env.dist, etc.)
+- [ ] Unit tests created or updated (see `test.bats` file)
+
+### Release PR Checklist
+- [ ] Update version number in `ecs-deploy` script
+- [ ] Give the PR a title of `Release _._._ - Summary of change` (using whatever
+      the new version number is, plus a succinct summary of what changed)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
-ecsdeploy:
-    build: .
-    env_file:
-        - local.env
-    volumes:
-        - ./ecs-deploy:/ecs-deploy
+services:
+    ecsdeploy:
+        build: .
+        env_file:
+            - local.env
+        volumes:
+            - ./ecs-deploy:/ecs-deploy
 
-test:
-    build: .
-    env_file:
-        - local.env
-    entrypoint: ["bash"]
-    command: ["/run-tests.sh"]
-    volumes:
-        - ./ecs-deploy:/ecs-deploy
-        - ./run-tests.sh:/run-tests.sh
-        - ./test.bats:/test.bats
+    test:
+        build: .
+        env_file:
+            - local.env
+        entrypoint: ["bash"]
+        command: ["/run-tests.sh"]
+        volumes:
+            - ./ecs-deploy:/ecs-deploy
+            - ./run-tests.sh:/run-tests.sh
+            - ./test.bats:/test.bats

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.13"
+VERSION="3.10.15"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.15"
+VERSION="3.10.16"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false

--- a/test.bats
+++ b/test.bats
@@ -670,3 +670,19 @@ EOF
   [ ! -z $status ]
   [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }
+
+@test "test parseImageName using image starting with underscore" {
+  IMAGE="_something:tag123"
+  TAGVAR=false
+  run parseImageName
+  [ $status -eq 13 ]
+}
+
+@test "test parseImageName using image containing an underscore in tag name" {
+  IMAGE="something:tag_123"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "something:tag_123" ]
+  echo "output = $output" 1>&2
+}


### PR DESCRIPTION
### Removed
- README and ecs-deploy no longer list silintl/mariadb as an example

### Fixed
- Fixed tag name regular expression to allow underscores.

---

### Release PR Checklist
- [x] Update version number in `ecs-deploy` script
- [x] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
