### PR TITLE
Release 3.10.19 --GHCR.io image push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME}}
-          password: ${{ secrets.DOCKERHUB_TOKEN}}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       
     # Step to login to GitHub Container Registry
       - name: Log in to GHCR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Continuous Integration
 
 on:
   push:
+    branches: ['master','main']  # Trigger on the pushes to master & main branches
+    tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   test:
@@ -18,19 +20,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+      
+    # Step to login to DockerHub
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+          username: ${{ secrets.DOCKERHUB_USERNAME}}
+          password: ${{ secrets.DOCKERHUB_TOKEN}}
+      
+    # Step to login to GitHub Container Registry
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor}}
+          password: ${{ secrets.GITHUB_TOKEN}}
+      
+    # Extract metadata for the Docker images using the semver
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKER_ORG }}/ecs-deploy
+          images: |
+            ${{ vars.DOCKER_ORG }}/ecs-deploy  # the name needs to be static "ecs-deploy"
+            ghcr.io/${{ github.repository_owner }}/ecs-deploy
+          tags: |
+           type=semver,pattern={{version}}
+          
 
+    # Build and push Docker image to GHCR and Docker Hub
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -38,3 +56,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
             ${{ vars.DOCKER_ORG }}/ecs-deploy  # the name needs to be static "ecs-deploy"
             ghcr.io/${{ github.repository_owner }}/ecs-deploy
           tags: |
-           type=semver,pattern={{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major.minor}}
           
 
     # Build and push Docker image to GHCR and Docker Hub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          #adding a line
 
 
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,5 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          #adding a line
-
-
-      
+          labels: ${{ steps.meta.outputs.labels }}    
+          

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.18"
+VERSION="3.10.19"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false


### PR DESCRIPTION
Added
-  version 3.10.19
- Pushing the Docker images to ghcr.io (Git Container Registry)   

### Release PR Checklist
- [ ] Update version number in `ecs-deploy` script
- [ ] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
