### PR TITLE
Add support for container image with digest

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -46,7 +46,7 @@ Required arguments:
     -p | --profile               AWS Profile to use - If you set this, then aws-access-key, aws-secret-key and region are not needed
     -c | --cluster               Name of ECS cluster
     -i | --image                 Name of Docker image to run, ex: repo/image:latest
-                                 Format: [domain][:port][/repo][/][image][:tag | @digest]
+                                 Format: [domain][:port][/repo][/][image][:tag|@digest]
                                  Examples: mariadb, mariadb:latest, private.registry.com:8000/repo/image:tag
     --aws-instance-profile       Use the IAM role associated with this instance
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -46,7 +46,7 @@ Required arguments:
     -p | --profile               AWS Profile to use - If you set this, then aws-access-key, aws-secret-key and region are not needed
     -c | --cluster               Name of ECS cluster
     -i | --image                 Name of Docker image to run, ex: repo/image:latest
-                                 Format: [domain][:port][/repo][/][image][:tag]
+                                 Format: [domain][:port][/repo][/][image][:tag | @digest]
                                  Examples: mariadb, mariadb:latest, private.registry.com:8000/repo/image:tag
     --aws-instance-profile       Use the IAM role associated with this instance
 
@@ -210,12 +210,13 @@ function parseImageName() {
     # - port
     # - repo
     # - image
-    # - tag
+    # - tagOrDigest
+    # - emptyOrSha
     # If a group is missing it will be an empty string
     if [[ "x$TAGONLY" == "x" ]]; then
-       imageRegex="^([a-zA-Z0-9\.\-]+):?([0-9]+)?/([a-zA-Z0-9\._\-]+)(/[\/a-zA-Z0-9\._\-]+)?:?([a-zA-Z0-9\._\-]+)?$"
+      imageRegex="^([a-zA-Z0-9\.\-]+):?([0-9]+)?/([a-zA-Z0-9\._\-]+)(/[\/a-zA-Z0-9\._\-]+)?:?((@sha256:)?[a-zA-Z0-9\._\-]+)?$"
     else
-       imageRegex="^:?([a-zA-Z0-9\._-]+)?$"
+      imageRegex="^:?([a-zA-Z0-9\._-]+)?$"
     fi
 
     if [[ $IMAGE =~ $imageRegex ]]; then
@@ -225,7 +226,13 @@ function parseImageName() {
         port=${BASH_REMATCH[2]}
         repo=${BASH_REMATCH[3]}
         img=${BASH_REMATCH[4]/#\//}
-        tag=${BASH_REMATCH[5]}
+        tagOrDigest=${BASH_REMATCH[5]}
+        emptyOrSha=${BASH_REMATCH[6]}
+        if [[ "x$emptyOrSha" == "x" ]]; then
+          tag=${tagOrDigest}
+        else
+          digest=${tagOrDigest}
+        fi
 
         # Validate what we received to make sure we have the pieces needed
         if [[ "x$domain" == "x" ]]; then
@@ -251,14 +258,20 @@ function parseImageName() {
       fi
     else
       # check if using root level repo with format like mariadb or mariadb:latest
-      rootRepoRegex="^([a-zA-Z0-9\-]+):?([a-zA-Z0-9\.\-_]+)?$"
+      rootRepoRegex="^([a-zA-Z0-9\-]+):?((@sha256:)?[a-zA-Z0-9\.\-_]+)?$"
       if [[ $IMAGE =~ $rootRepoRegex ]]; then
         img=${BASH_REMATCH[1]}
         if [[ "x$img" == "x" ]]; then
           echo "Invalid image name. See usage for supported formats."
           exit 12
         fi
-        tag=${BASH_REMATCH[2]}
+        tagOrDigest=${BASH_REMATCH[2]}
+        emptyOrSha=${BASH_REMATCH[3]}
+        if [[ "x$emptyOrSha" == "x" ]]; then
+          tag=${tagOrDigest}
+        else
+          digest=${tagOrDigest}
+        fi
 
         # for root level repo, initialize unused variables for checks when rebuilding image below
         domain=""
@@ -279,6 +292,9 @@ function parseImageName() {
         tag=${!TAGVAR}
         if [[ "x$tag" == "x" ]]; then
           tag="latest"
+        else 
+          # If !TAGVAR isn't empty, we should use the value of the env var as the tag whether IMAGE contains a digest or not.
+          emptyOrSha=""
         fi
       fi
     fi
@@ -304,7 +320,9 @@ function parseImageName() {
         fi
       fi
       imageWithoutTag="$useImage"
-      if [[ ! -z "$tag" ]]; then
+      if [[ ! -z "$emptyOrSha" ]]; then
+        useImage="$useImage$digest"
+        else
         useImage="$useImage:$tag"
       fi
 

--- a/test.bats
+++ b/test.bats
@@ -94,6 +94,14 @@ setup() {
   [ "$output" == "mariadb:1.2.3" ]
 }
 
+@test "test parseImageName root image with digest" {
+  IMAGE="mariadb@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "mariadb@sha256:1234567890abcdef" ]
+}
+
 @test "test parseImageName repo image no tag" {
   IMAGE="repo/image"
   TAGVAR=false
@@ -108,6 +116,14 @@ setup() {
   run parseImageName
   [ ! -z $status ]
   [ "$output" == "repo/image:v1.2.3" ]
+}
+
+@test "test parseImageName repo image with digest" {
+  IMAGE="repo/image@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "repo/image@sha256:1234567890abcdef" ]
 }
 
 @test "test parseImageName repo multilevel image no tag" {
@@ -126,6 +142,14 @@ setup() {
   [ "$output" == "repo/multi/level/image:v1.2.3" ]
 }
 
+@test "test parseImageName repo multilevel image with digest" {
+  IMAGE="repo/multi/level/image@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "repo/multi/level/image@sha256:1234567890abcdef" ]
+}
+
 @test "test parseImageName domain plus repo image no tag" {
   IMAGE="docker.domain.com/repo/image"
   TAGVAR=false
@@ -140,6 +164,14 @@ setup() {
   run parseImageName
   [ ! -z $status ]
   [ "$output" == "docker.domain.com/repo/image:1.2.3" ]
+}
+
+@test "test parseImageName domain plus repo image with digest" {
+  IMAGE="docker.domain.com/repo/image@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "docker.domain.com/repo/image@sha256:1234567890abcdef" ]
 }
 
 @test "test parseImageName domain plus repo multilevel image no tag" {
@@ -158,6 +190,14 @@ setup() {
   [ "$output" == "docker.domain.com/repo/multi/level/image:1.2.3" ]
 }
 
+@test "test parseImageName domain plus repo multilevel image with digest" {
+  IMAGE="docker.domain.com/repo/multi/level/image@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "docker.domain.com/repo/multi/level/image@sha256:1234567890abcdef" ]
+}
+
 @test "test parseImageName domain plus port plus repo image no tag" {
   IMAGE="docker.domain.com:8080/repo/image"
   TAGVAR=false
@@ -174,6 +214,14 @@ setup() {
   [ "$output" == "docker.domain.com:8080/repo/image:1.2.3" ]
 }
 
+@test "test parseImageName domain plus port plus repo image with digest" {
+  IMAGE="docker.domain.com:8080/repo/image@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "docker.domain.com:8080/repo/image@sha256:1234567890abcdef" ]
+}
+
 @test "test parseImageName domain plus port plus repo multilevel image no tag" {
   IMAGE="docker.domain.com:8080/repo/multi/level/image"
   TAGVAR=false
@@ -188,6 +236,14 @@ setup() {
   run parseImageName
   [ ! -z $status ]
   [ "$output" == "docker.domain.com:8080/repo/multi/level/image:1.2.3" ]
+}
+
+@test "test parseImageName domain plus port plus repo multilevel image with digest" {
+  IMAGE="docker.domain.com:8080/repo/multi/level/image@sha256:1234567890abcdef"
+  TAGVAR=false
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "docker.domain.com:8080/repo/multi/level/image@sha256:1234567890abcdef" ]
 }
 
 @test "test parseImageName domain plus port plus repo image with tag from var" {
@@ -223,6 +279,15 @@ setup() {
   run parseImageName
   [ ! -z $status ]
   [ "$output" == "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1487623908" ]
+}
+
+@test "test parseImageName using ecr style image name and tag from var with digest" {
+  IMAGE="docker.domain.com:8080/repo/image@sha256:1234567890abcdef"
+  TAGVAR="CI_TIMESTAMP"
+  CI_TIMESTAMP="1487623908"
+  run parseImageName
+  [ ! -z $status ]
+  [ "$output" == "docker.domain.com:8080/repo/image:1487623908" ]
 }
 
 @test "test createNewTaskDefJson with single container in definition" {


### PR DESCRIPTION
`ecs-deploy` is in maintenance mode, but this change is backward-compatible and addresses a necessary use case by enabling support for container images with digests.

I would appreciate it if you could consider merging it.

### Added
- Support container image with digest.
- Add tests for container image with digest.

### Related issues

https://github.com/silinternational/ecs-deploy/issues/294

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, etc.)
- [x] Unit tests created or updated (see `test.bats` file)

