### PR TITLE
Release 3.10.22 -- fix task definition creation with multiple similar images defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Continuous Integration
 
 on:
   push:
-    branches: ['master','main']  # Trigger on the pushes to master & main branches
-    tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   test:
@@ -18,25 +16,23 @@ jobs:
     name: Build and Publish
     needs: test
     runs-on: ubuntu-latest
+    if: github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
-      
-    # Step to login to DockerHub
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-    # Step to login to GitHub Container Registry
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor}}
           password: ${{ secrets.GITHUB_TOKEN}}
-      
-    # Extract metadata for the Docker images using the semver
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -50,12 +46,10 @@ jobs:
             type=semver,pattern={{major.minor}}
           
 
-    # Build and push Docker image to GHCR and Docker Hub
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}    
-          
+          labels: ${{ steps.meta.outputs.labels }}

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.21"
+VERSION="3.10.22"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false
@@ -292,7 +292,7 @@ function parseImageName() {
         tag=${!TAGVAR}
         if [[ "x$tag" == "x" ]]; then
           tag="latest"
-        else 
+        else
           # If !TAGVAR isn't empty, we should use the value of the env var as the tag whether IMAGE contains a digest or not.
           emptyOrSha=""
         fi
@@ -379,7 +379,7 @@ function createNewTaskDefJson() {
     # + Filter the def
     if [[ "x$TAGONLY" == "x" ]]; then
       DEF=$( echo "$taskDefinition" \
-            | sed -e 's~"image":.*'"${imageWithoutTag}"'.*,~"image": "'"${useImage}"'",~g' \
+            | sed -e 's~"image":.*'"${imageWithoutTag}:"'.*,~"image": "'"${useImage}"'",~g' \
             | jq '.taskDefinition' )
     else
       DEF=$( echo "$taskDefinition" \

--- a/test.bats
+++ b/test.bats
@@ -467,7 +467,7 @@ EOF
                 "name": "cache",
                 "links": [],
                 "mountPoints": [],
-                "image": "arn:aws:ecs:us-east-1:121212345678:task-definition/app-task-def-two:123",
+                "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo-two:1487623908",
                 "essential": true,
                 "portMappings": [
                     {
@@ -491,7 +491,7 @@ EOF
 }
 EOF
 )
-  expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] }, { "environment": [ { "name": "KEY", "value": "value" } ], "name": "cache", "links": [], "mountPoints": [], "image": "redis:latest", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 6376, "hostPort": 10376 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "bridge" }'
+  expected='{ "family": "app-task-def", "volumes": [], "containerDefinitions": [ { "environment": [ { "name": "KEY", "value": "value" } ], "name": "API", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo:1111111111", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 80, "hostPort": 10080 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] }, { "environment": [ { "name": "KEY", "value": "value" } ], "name": "cache", "links": [], "mountPoints": [], "image": "121212345678.dkr.ecr.us-east-1.amazonaws.com/acct/repo-two:1487623908", "essential": true, "portMappings": [ { "protocol": "tcp", "containerPort": 6376, "hostPort": 10376 } ], "entryPoint": [], "memory": 128, "command": [ "/data/run.sh" ], "cpu": 200, "volumesFrom": [] } ], "placementConstraints": null, "networkMode": "bridge" }'
   run createNewTaskDefJson
   [ ! -z $status ]
   [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]

--- a/test.bats
+++ b/test.bats
@@ -467,7 +467,7 @@ EOF
                 "name": "cache",
                 "links": [],
                 "mountPoints": [],
-                "image": "redis:latest",
+                "image": "arn:aws:ecs:us-east-1:121212345678:task-definition/app-task-def-two:123",
                 "essential": true,
                 "portMappings": [
                     {


### PR DESCRIPTION

### Fixed
- Fixes #303 
   
When multiple images with similar names are used in the container definition, this will ensure only the specified one will be updated. 


---

### Release PR Checklist
- [x] Update version number in `ecs-deploy` script
- [x] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
