### PR TITLE
Release 3.10.25 - fix bug in updateService()

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.24"
+VERSION="3.10.25"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false
@@ -486,7 +486,7 @@ function updateService() {
                 | jq -r '.taskArns[]')
 
             if [[ ! -z "$RUNNING_TASKS" ]] ; then
-                RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks "$RUNNING_TASKS" \
+                RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks $RUNNING_TASKS \
                     | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.${checkFieldName}" \
                     | grep -e "${checkFieldValue}") || :
 


### PR DESCRIPTION

### Fixed
- Fixed a bug in `updateService()` where the addition of quotes breaks the aws describe-tasks call. The correct code splits the jq-parsed list of running tasks on newlines and passes it as separate arguments to the aws cli. The broken code retains the newlines received from jq, which is interpreted incorrectly by the aws cli.

---

### Release PR Checklist
- [x] Update version number in `ecs-deploy` script
- [x] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
