### PR TITLE
Release 3.10.26 - Fixing syntax error when waiting for task and/or service to update

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.25"
+VERSION="3.10.26"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -516,7 +516,7 @@ function updateService() {
             fi
 
             sleep "$every"
-            i=$(( "$i" + "$every" ))
+            i=$(( i + every ))
         done
 
         if [[ "${UPDATE_SERVICE_SUCCESS}" != "true" ]]; then
@@ -550,7 +550,7 @@ function waitForGreenDeployment {
       i="$TIMEOUT"
     else
       sleep "$every"
-      i=$(( "$i" + "$every" ))
+      i=$(( i + every ))
     fi
   done
 
@@ -605,7 +605,7 @@ function runTask {
         echo "Checking task status every $every seconds. Status: $TASK_STATUS"
 
         sleep "$every"
-        i=$(( "$i" + "$every" ))
+        i=$(( i + every ))
     done
 
     if [ "$RUN_TASK_SUCCESS" == false ]; then


### PR DESCRIPTION
Fixing syntax error: operand expected (error token is ""0" + "10" ")

### Added
- 

### Changed (non-breaking)
-

### Changed (BREAKING)
-

### Deprecated
-

### Removed
-

### Fixed
- Fixing syntax error: operand expected (error token is ""0" + "10" ") caused by PR #311 

### Security
-

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, etc.)
- [x] Unit tests created or updated (see `test.bats` file)

### Release PR Checklist
- [x] Update version number in `ecs-deploy` script
- [x] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
