### PR TITLE
ITSE-902: Fix --max-definitions ignored in task-def mode

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -442,22 +442,25 @@ function updateServiceForceNewDeployment() {
     $AWS_ECS update-service --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment > /dev/null
 }
 
+function getOutdatedTaskDefinitions() {
+    local taskRevisions="$1"
+    local maxDefinitions="$2"
+    local numActiveRevisions
+    numActiveRevisions=$(echo "$taskRevisions" | jq ".taskDefinitionArns|length")
+    if [[ "$numActiveRevisions" -gt "$maxDefinitions" ]]; then
+        echo "$taskRevisions" | jq -r ".taskDefinitionArns[0:$((numActiveRevisions - maxDefinitions))][]"
+    fi
+}
+
 function deregisterOutdatedTaskDefinitions() {
     if [[ "$MAX_DEFINITIONS" -gt 0 ]]; then
         FAMILY_PREFIX=${TASK_DEFINITION_ARN##*:task-definition/}
         FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
         TASK_REVISIONS=$($AWS_ECS list-task-definitions --family-prefix "$FAMILY_PREFIX" --status ACTIVE --sort ASC)
-        NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
-        if [[ "$NUM_ACTIVE_REVISIONS" -gt "$MAX_DEFINITIONS" ]]; then
-            LAST_OUTDATED_INDEX=$((NUM_ACTIVE_REVISIONS - MAX_DEFINITIONS - 1))
-            for i in $(seq 0 "$LAST_OUTDATED_INDEX"); do
-                OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
-
-                echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
-
-                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
-            done
-        fi
+        for OUTDATED_REVISION_ARN in $(getOutdatedTaskDefinitions "$TASK_REVISIONS" "$MAX_DEFINITIONS"); do
+            echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
+            $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
+        done
     fi
 }
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -442,6 +442,25 @@ function updateServiceForceNewDeployment() {
     $AWS_ECS update-service --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment > /dev/null
 }
 
+function deregisterOutdatedTaskDefinitions() {
+    if [[ "$MAX_DEFINITIONS" -gt 0 ]]; then
+        FAMILY_PREFIX=${TASK_DEFINITION_ARN##*:task-definition/}
+        FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
+        TASK_REVISIONS=$($AWS_ECS list-task-definitions --family-prefix "$FAMILY_PREFIX" --status ACTIVE --sort ASC)
+        NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
+        if [[ "$NUM_ACTIVE_REVISIONS" -gt "$MAX_DEFINITIONS" ]]; then
+            LAST_OUTDATED_INDEX=$((NUM_ACTIVE_REVISIONS - MAX_DEFINITIONS - 1))
+            for i in $(seq 0 "$LAST_OUTDATED_INDEX"); do
+                OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
+
+                echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
+
+                $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
+            done
+        fi
+    fi
+}
+
 function updateService() {
     if [[ $(echo "${NEW_DEF}" | jq ".containerDefinitions[0].healthCheck != null") == true ]]; then
         checkFieldName="healthStatus"
@@ -493,23 +512,8 @@ function updateService() {
                 if [ "$RUNNING" ]; then
                     echo "Service updated successfully, new task definition running.";
 
-                    if [[ "$MAX_DEFINITIONS" -gt 0 ]]; then
-                        FAMILY_PREFIX=${TASK_DEFINITION_ARN##*:task-definition/}
-                        FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
-                        TASK_REVISIONS=$($AWS_ECS list-task-definitions --family-prefix "$FAMILY_PREFIX" --status ACTIVE --sort ASC)
-                        NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
-                        if [[ "$NUM_ACTIVE_REVISIONS" -gt "$MAX_DEFINITIONS" ]]; then
-                            LAST_OUTDATED_INDEX=$((NUM_ACTIVE_REVISIONS - MAX_DEFINITIONS - 1))
-                            for i in $(seq 0 "$LAST_OUTDATED_INDEX"); do
-                                OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
+                    deregisterOutdatedTaskDefinitions
 
-                                echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
-
-                              $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
-                            done
-                        fi
-
-                    fi
                     UPDATE_SERVICE_SUCCESS="true"
                     break
                 fi
@@ -803,6 +807,7 @@ if [ "$BASH_SOURCE" == "$0" ]; then
 
     # update service if needed
     if [ "$SERVICE" == false ]; then
+        deregisterOutdatedTaskDefinitions
         if [ "$RUN_TASK" == true ]; then
             runTask
         fi

--- a/test.bats
+++ b/test.bats
@@ -811,3 +811,23 @@ EOF
   [ ! -z $status ]
   [ "$(echo "$output" | jq .)" == "$(echo "$expected" | jq .)" ]
 }
+
+# getOutdatedTaskDefinitions tests
+# Pure function: given the ACTIVE revisions JSON and a max, returns the ARNs to deregister.
+
+@test "test getOutdatedTaskDefinitions returns oldest revisions beyond max" {
+  revisions='{ "taskDefinitionArns": [ "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:1", "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:2", "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:3", "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:4", "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:5" ] }'
+  run getOutdatedTaskDefinitions "$revisions" 2
+  [ ! -z $status ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" == "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:1" ]
+  [ "${lines[1]}" == "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:2" ]
+  [ "${lines[2]}" == "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:3" ]
+}
+
+@test "test getOutdatedTaskDefinitions returns nothing when within max" {
+  revisions='{ "taskDefinitionArns": [ "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:1", "arn:aws:ecs:us-east-1:123456789012:task-definition/app-task-def:2" ] }'
+  run getOutdatedTaskDefinitions "$revisions" 5
+  [ ! -z $status ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
[ITSE-902](https://support.gtis.sil.org/issue/ITSE-902) ecs-deploy --max-definitions is ignored in task definition mode
### Changed (non-breaking)
- extracted revision-pruning into `getOutdatedTaskDefinitions()` (pure) + `deregisterOutdatedTaskDefinitions()` (AWS wrapper).

### Fixed
- `--max-definitions` ignored in `--task-definition` mode; pruning now runs there too

