### PR TITLE
Release 3.10.27: bumps VERSION for the fix merged in #314.

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup default values for variables
-VERSION="3.10.26"
+VERSION="3.10.27"
 CLUSTER=false
 SERVICE=false
 TASK_DEFINITION=false


### PR DESCRIPTION
Release 3.10.27 - bumps VERSION for the fix merged in #314.

### Fixed
- `--max-definitions` now honored in `--task-definition` mode (#314).

### Release PR Checklist
- [X] Update version number in `ecs-deploy` script
- [X] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
